### PR TITLE
HOTFIX: Bootstrap User Config Directory on Windows

### DIFF
--- a/tidal_wave/__main__.py
+++ b/tidal_wave/__main__.py
@@ -1,2 +1,3 @@
 from .main import app
+
 app()

--- a/tidal_wave/login.py
+++ b/tidal_wave/login.py
@@ -187,7 +187,9 @@ def login_windows(
 ) -> Optional[requests.Session]:
     _token: Optional[str] = load_token_from_disk(token_path=token_path)
     if _token is None:
-        _token: str = typer.prompt("Enter Tidal API access token (the part after 'Bearer '): ")
+        _token: str = typer.prompt(
+            "Enter Tidal API access token (the part after 'Bearer '): "
+        )
 
     s: Optional[requests.Session] = validate_token(_token)
     if s is None:
@@ -224,11 +226,15 @@ def login(
     AudioFormat instance passed in; or (None, "") in the event of error.
     """
     android_formats: Set[AudioFormat] = {
-        AudioFormat.sony_360_reality_audio, AudioFormat.hi_res
+        AudioFormat.sony_360_reality_audio,
+        AudioFormat.hi_res,
     }
     fire_tv_formats: Set[AudioFormat] = {
-        AudioFormat.dolby_atmos, AudioFormat.mqa, AudioFormat.lossless,
-        AudioFormat.high,  AudioFormat.low
+        AudioFormat.dolby_atmos,
+        AudioFormat.mqa,
+        AudioFormat.lossless,
+        AudioFormat.high,
+        AudioFormat.low,
     }
     if audio_format in fire_tv_formats:
         return (login_fire_tv(), audio_format)

--- a/tidal_wave/login.py
+++ b/tidal_wave/login.py
@@ -5,7 +5,7 @@ import logging
 from pathlib import Path
 import platform
 import sys
-from typing import Dict, Optional, Tuple
+from typing import Dict, Optional, Set, Tuple
 
 from .models import BearerAuth, SessionsEndpointResponseJSON
 from .oauth import (
@@ -20,11 +20,11 @@ from .utils import TIDAL_API_URL
 
 from platformdirs import user_config_path
 import requests
+import typer
 
-# https://stackoverflow.com/a/66169954
 PROJECT_NAME: str = "tidal-wave"
-PROJECT_AUTHOR: str = "colinho"
-TOKEN_DIR_PATH = user_config_path(appname=PROJECT_NAME, appauthor=PROJECT_AUTHOR)
+TOKEN_DIR_PATH = user_config_path() / PROJECT_NAME
+TOKEN_DIR_PATH.mkdir(exist_ok=True, parents=True)
 
 COMMON_HEADERS: Dict[str, str] = {"Accept-Encoding": "gzip, deflate, br"}
 
@@ -113,26 +113,26 @@ def validate_token(
 def login_fire_tv(
     token_path: Path = TOKEN_DIR_PATH / "fire_tv-tidal.token",
 ) -> Optional[requests.Session]:
-    try:
-        bearer_token = BearerToken.load(p=token_path)
-    except TokenException as te:
-        logger.exception(te)
+    # new approach so that FileNotFoundError, which is handled,
+    # does not explode on the STDERR output:
+    bearer_token = BearerToken.load(p=token_path)
+    if bearer_token is not None:
+        bearer_token.save(p=token_path)
+    else:
         to = TidalOauth()
         bearer_token = to.authorization_code_flow()
-    else:
         logger.info("Successfully loaded token from disk.")
-    finally:
         bearer_token.save(p=token_path)
 
     # check if access needs refreshed
     if bearer_token.is_expired:
-        logger.warning("Tidal API token needs refreshing: Attempting now.")
+        logger.warning("TIDAL access token needs refreshing: Attempting now.")
         try:
             bearer_token.refresh()
         except TokenException as te:
             sys.exit(te.args[0])
         else:
-            logger.info("Successfully refreshed Tidal API token")
+            logger.info("Successfully refreshed TIDAL access token")
 
     s: Optional[requests.Session] = validate_token(bearer_token.access_token)
     if s is None:
@@ -147,14 +147,18 @@ def login_fire_tv(
 def login_android(
     token_path: Path = TOKEN_DIR_PATH / "android-tidal.token",
 ) -> Optional[requests.Session]:
-    logger.info(f"Loading TIDAL API token from {str(token_path.absolute())}")
+    logger.info(f"Loading TIDAL access token from '{str(token_path.absolute())}'")
     _token: Optional[str] = load_token_from_disk(token_path=token_path)
     device_type: Optional[str] = None
 
     if _token is None:
-        logger.warning("Could not load bearer token from disk")
-        _token: str = input("Enter Tidal API Bearer token from an Android device: ")
-        dt_input: str = input("Is this from device type: phone, tablet, or other? ")
+        logger.warning("Could not load access token from disk")
+        _token: str = typer.prompt(
+            "Enter TIDAL access token from an Android (the part after 'Bearer '): "
+        )
+        dt_input: str = typer.prompt(
+            "Is this from device type: phone, tablet, or other? "
+        )
         if dt_input.lower() == "phone":
             device_type = "PHONE"
         elif dt_input.lower() == "tablet":
@@ -162,11 +166,11 @@ def login_android(
 
     s: Optional[requests.Session] = validate_token(_token)
     if s is None:
-        logger.critical("Bearer token is not valid: exiting now.")
+        logger.critical("Access token is not valid: exiting now.")
         if token_path.exists():
             token_path.unlink()
     else:
-        logger.info(f"Bearer token is valid: saving to {str(token_path.absolute())}")
+        logger.info(f"Access token is valid: saving to {str(token_path.absolute())}")
         if device_type is not None:
             s.params["deviceType"] = device_type
 
@@ -188,13 +192,13 @@ def login_windows(
 ) -> Optional[requests.Session]:
     _token: Optional[str] = load_token_from_disk(token_path=token_path)
     if _token is None:
-        _token: str = input("Enter Tidal API Bearer token: ")
+        _token: str = typer.prompt("Enter Tidal API access token (the part after 'Bearer '): ")
 
     s: Optional[requests.Session] = validate_token(_token)
     if s is None:
-        logger.critical("Bearer token is not valid: exiting now.")
+        logger.critical("Access token is not valid: exiting now.")
     else:
-        logger.debug(f"Writing this bearer token to '{str(token_path.absolute())}'")
+        logger.debug(f"Writing this access token to '{str(token_path.absolute())}'")
         # s.headers["User-Agent"] = "Mozilla/5.0 (Windows NT 10.0; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) TIDAL/2.35.0 Chrome/108.0.5359.215 Electron/22.3.27 Safari/537.36"
         s.headers["User-Agent"] = "TIDAL_NATIVE_PLAYER/WIN/3.1.2.195"
         s.params["deviceType"] = "DESKTOP"
@@ -224,32 +228,27 @@ def login(
     Returns a tuple of a requests.Session object, if no error, and the
     AudioFormat instance passed in; or (None, "") in the event of error.
     """
-    if audio_format == AudioFormat.sony_360_reality_audio:
-        return (login_android(), audio_format)
-    elif audio_format == AudioFormat.dolby_atmos:
+    android_formats: Set[AudioFormat] = {
+        AudioFormat.sony_360_reality_audio, AudioFormat.hi_res
+    }
+    fire_tv_formats: Set[AudioFormat] = {
+        AudioFormat.dolby_atmos, AudioFormat.mqa, AudioFormat.lossless,
+        AudioFormat.high,  AudioFormat.low
+    }
+    if audio_format in fire_tv_formats:
         return (login_fire_tv(), audio_format)
-    elif audio_format == AudioFormat.hi_res:
-        options: set = {"android", "a", "windows", "w", "macos", "mac", "m"}
+    elif audio_format in android_formats:
+        options: set = {"android", "a", "windows", "w"}
         _input: str = ""
         while _input not in options:
-            _input = input(
-                "For which of Android [a], Windows [w], or MacOS [m] would you like to provide an API token? "
+            _input = typer.prompt(
+                "For which of Android [a] or Windows [w] would you like to provide an API token? "
             ).lower()
         else:
             if _input in {"android", "a"}:
                 return (login_android(), audio_format)
             elif _input in {"windows", "w"}:
                 return (login_windows(), audio_format)
-            elif _input in {"macos", "mac", "m"}:
-                raise NotImplementedError
-    elif audio_format == AudioFormat.mqa:
-        return (login_fire_tv(), audio_format)
-    elif audio_format == AudioFormat.lossless:
-        return (login_fire_tv(), audio_format)
-    elif audio_format == AudioFormat.high:
-        return (login_fire_tv(), audio_format)
-    elif audio_format == AudioFormat.low:
-        return (login_fire_tv(), audio_format)
     else:
         logger.critical(
             "Please provide one of the following: "

--- a/tidal_wave/login.py
+++ b/tidal_wave/login.py
@@ -9,7 +9,6 @@ from typing import Dict, Optional, Set, Tuple
 
 from .models import BearerAuth, SessionsEndpointResponseJSON
 from .oauth import (
-    PROJECT_AUTHOR,
     PROJECT_NAME,
     TOKEN_DIR_PATH,
     BearerToken,
@@ -21,10 +20,6 @@ from .utils import TIDAL_API_URL
 from platformdirs import user_config_path
 import requests
 import typer
-
-PROJECT_NAME: str = "tidal-wave"
-TOKEN_DIR_PATH = user_config_path() / PROJECT_NAME
-TOKEN_DIR_PATH.mkdir(exist_ok=True, parents=True)
 
 COMMON_HEADERS: Dict[str, str] = {"Accept-Encoding": "gzip, deflate, br"}
 

--- a/tidal_wave/main.py
+++ b/tidal_wave/main.py
@@ -37,7 +37,6 @@ def main(
         LogLevel, typer.Option(case_sensitive=False)
     ] = LogLevel.info.value,
 ):
-
     logging.basicConfig(
         format="%(asctime)s,%(msecs)03d %(levelname)-8s [%(filename)s:%(lineno)d] %(message)s",
         datefmt="%Y-%m-%d:%H:%M:%S",

--- a/tidal_wave/media.py
+++ b/tidal_wave/media.py
@@ -410,9 +410,7 @@ class Track:
             self.download_headers["sessionId"] = session.session_id
         self.download_params = {"deviceType": None, "locale": None, "countryCode": None}
         # self.outfile should already have been setted by set_outfile()
-        logger.info(
-            f"Writing track {self.track_id} to {str(self.outfile.absolute())}"
-        )
+        logger.info(f"Writing track {self.track_id} to {str(self.outfile.absolute())}")
 
         with NamedTemporaryFile() as ntf:
             for u in urls:

--- a/tidal_wave/oauth.py
+++ b/tidal_wave/oauth.py
@@ -218,9 +218,7 @@ class BearerToken:
             if token_json.get("userId", token_json.get("user_id")) is not None:
                 self.user_id = token_json.get("userId", token_json.get("user_id"))
             if token_json.get("userName", token_json.get("user_name")) is not None:
-                self.user_name = token_json.get(
-                    "userName", token_json.get("user_name")
-                )
+                self.user_name = token_json.get("userName", token_json.get("user_name"))
 
             _timedelta = timedelta(seconds=token_json.get("expires_in") - 300)
             self.expiration = datetime.now(tz=timezone.utc) + _timedelta

--- a/tidal_wave/oauth.py
+++ b/tidal_wave/oauth.py
@@ -17,8 +17,8 @@ from platformdirs import user_config_path
 import requests
 
 PROJECT_NAME: str = "tidal-wave"
-PROJECT_AUTHOR: str = "colinho"
-TOKEN_DIR_PATH = user_config_path(appname=PROJECT_NAME, appauthor=PROJECT_AUTHOR)
+TOKEN_DIR_PATH: Path = user_config_path() / PROJECT_NAME
+TOKEN_DIR_PATH.mkdir(exist_ok=True, parents=True)
 OAUTH2_URL: str = "https://auth.tidal.com/v1/oauth2"
 OAUTH2_HEADERS: Dict[str, str] = {
     "User-Agent": "TIDAL_ANDROID/2.38.0",
@@ -82,8 +82,8 @@ class TokenEndpointResponseJSON(dataclass_wizard.JSONSerializable):
     """This class models the JSON response from the Tidal API
     authorization /token endpoint."""
 
-    # scope: str
-    # user: "User"
+    scope: str
+    user: "User"
     client_name: str
     token_type: str
     access_token: str
@@ -145,21 +145,31 @@ class BearerToken:
         p.write_bytes(outdata)
 
     @classmethod
-    def load(cls, p: Path = TOKEN_DIR_PATH / "fire_tv-tidal.token") -> "BearerToken":
-        """Read base64-encoded JSON object from disk"""
+    def load(
+        cls, p: Path = TOKEN_DIR_PATH / "fire_tv-tidal.token"
+    ) -> Optional["BearerToken"]:
+        """Read base64-encoded JSON object from disk. If no error arises,
+        return a BearerToken instance; else, return None"""
 
         try:
             data = json.loads(base64.b64decode(p.read_bytes()))
         except FileNotFoundError:
-            raise TokenException(f"File '{str(p.absolute())}' does not exist")
+            logger.exception(
+                TokenException(f"File '{str(p.absolute())}' does not exist")
+            )
+            return
         except json.JSONDecodeError:
-            raise TokenException(
-                f"Could not parse JSON data from '{str(p.absolute())}'"
+            logger.exception(
+                TokenException(f"Could not parse JSON data from '{str(p.absolute())}'")
             )
+            return
         except UnicodeDecodeError:
-            raise TokenException(
-                f"File '{str(p.absolute())}' does not appear to be base64-encoded"
+            logger.exception(
+                TokenException(
+                    f"File '{str(p.absolute())}' does not appear to be base64-encoded"
+                )
             )
+            return
 
         data_args = (
             data.get(a)
@@ -209,7 +219,7 @@ class BearerToken:
                 self.user_id = token_json.get("userId", token_json.get("user_id"))
             if token_json.get("userName", token_json.get("user_name")) is not None:
                 self.user_name = token_json.get(
-                    "userName", token_json.get("user_nname")
+                    "userName", token_json.get("user_name")
                 )
 
             _timedelta = timedelta(seconds=token_json.get("expires_in") - 300)


### PR DESCRIPTION
Upon first time creation of user config on Windows, especially, the process breaks because the directory doesn't exist: make sure that the directory exists with the change on L21 of `oauth.py`.

Also, as the errors that propagated from this issue consumed the STDERR of the process, change the logic of `oauth.BearerToken.load()` to only *log* the exceptions instead of raise them; returning `None` that will later be dealt with by `login.py`.

Lastly, switch from Python built-in `input()` to `typer.Prompt()` for consistency across the app experience.