### PR TITLE
Revamp `media.py`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ requires = ["setuptools", "wheel"]
 universal = 0  # Make the generated wheels have "py3" tag
 [project]
 name = "tidal-wave"
-version = "2023.12.2"
+version = "2023.12.3"
 description = "A tool to wave at the TIDAL music service."
 authors = [
     {name = "colinho", email = "pypi@colin.technology"}

--- a/tidal_wave/media.py
+++ b/tidal_wave/media.py
@@ -488,10 +488,10 @@ class Track:
             tags[tag_map["lyrics"]] = _lyrics
         # track and disk
         if self.codec == "flac":
-            tags["disc_number"] = f"{self.metadata.volume_number}"
-            tags["discs"] = f"{self.album.number_of_volumes}"
-            tags["total_tracks"] = f"{self.album.number_of_tracks}"
-            tags["track_number"] = f"{self.metadata.track_number}"
+            tags["DISCTOTAL"] = f"{self.metadata.volume_number}"
+            tags["DISC"] = f"{self.album.number_of_volumes}"
+            tags["TRACKTOTAL"] = f"{self.album.number_of_tracks}"
+            tags["TRACKNUMBER"] = f"{self.metadata.track_number}"
         elif self.codec == "m4a":
             # Have to convert to bytes the values of the tags starting with '----'
             for k, v in tags.copy().items():


### PR DESCRIPTION
This pull request aims to bring in a necessary bug fix: #4 , as well as some code cleanup in `media.py`:
  * Make `media.Track.get()` take album and metadata arguments so that `media.Album.get_tracks()` can directly call `media.Track.get()`
  * If only 1 URL is presented by the manifest, GET it with HTTP range requests
  * Supporting the above, in `requesting.py` add three functions that generate range request headers for a given URL