### PR TITLE
Add artist URLs as top-level program option

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,11 +95,14 @@ Usage: tidal-wave [OPTIONS] TIDAL_URL [OUTPUT_DIRECTORY]
                                                                                                                                                                                             
 ╭─ Arguments ──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
 │ *    tidal_url             TEXT                The Tidal album or mix or playlist or track or video to download [default: None] [required]                                               │
-│      output_directory      [OUTPUT_DIRECTORY]  The parent directory under which files will be written [default: /home/$USER/Music]                                                       │
+│      output_directory      [OUTPUT_DIRECTORY]  The parent directory under which files will be written [default: /home/${USER}/Music]                                                     │
 ╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
 ╭─ Options ────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
-│ --audio-format        [360|Atmos|HiRes|MQA|Lossless|High|Low]         [default: Lossless]                                                                                                │
-│ --loglevel            [DEBUG|INFO|WARNING|ERROR|CRITICAL]             [default: INFO]                                                                                                    │
+│ --audio-format               [360|Atmos|HiRes|MQA|Lossless|High|Low]  [default: Lossless]                                                                                                │
+│ --loglevel                   [DEBUG|INFO|WARNING|ERROR|CRITICAL]      [default: INFO]                                                                                                    │
+│ --include-eps-singles                                                 No-op unless passing TIDAL artist. Whether to include artist's EPs and singles with albums                         │
+│ --install-completion                                                  Install completion for the current shell.                                                                          │
+│ --show-completion                                                     Show completion for the current shell, to copy it or customize the installation.                                   │
 │ --help                                                                Show this message and exit.                                                                                        │
 ╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
 ```
@@ -146,6 +149,16 @@ Similarly, all media retrieved is placed in subdirectories of the user's default
  ```bash
  $ ./tidal-wave_<VERSION>.pyapp https://tidal.com/browse/mix/...
  ```
+
+ - To (attempt to) get all of an artist's works (albums and videos, **excluding EPs and singles**) in Dolby Atmos format and verbose logging, the following will do that:
+ ```bash
+ (.venv) $ python3 -m tidal_wave https://listen.tidal.com/artist/... --audio-format atmos --loglevel debug
+ ```
+
+ - To (attempt to) get all of an artist's works (**including EPs and singles**), in HiRes format, the following will do that:
+ ```bash
+ (.venv) $ tidal-wave https://listen.tidal.com/artist/... --audio-format hires --include-eps-singles
+ ```
 #### Docker example
 The command line options are the same for the Python invocation, but in order to save configuration and audio data, volumes need to be passed. If they are bind mounts to directories, **they must be created before executing `docker run` to avoid permissions issues**! For example,
 ```bash
@@ -156,4 +169,17 @@ $ docker run \
     --volume ./config/tidal-wave:/home/debian/.config/tidal-wave \
     ghcr.io/ebb-earl-co/tidal-wave:latest \
     https://tidal.com/browse/track/...
+```
+
+Using Docker might be an attractive idea in the event that you want to retrieve all of the videos, albums, EPs, and singles in highest quality possible for a given artist. The following Docker invocation will do that for you:
+```bash
+$ mkdir -p ./Music/ ./config/tidal-wave/
+$ docker run \
+    --name tidal-wave \
+    --volume ./Music:/home/debian/Music \
+    --volume ./config/tidal-wave:/home/debian/.config/tidal-wave \
+    ghcr.io/ebb-earl-co/tidal-wave:latest \
+    https://listen.tidal.com/artist/... \
+    --audio-format hires \
+    --include-eps-singles
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ requires = ["setuptools", "wheel"]
 universal = 0  # Make the generated wheels have "py3" tag
 [project]
 name = "tidal-wave"
-version = "2023.12.10"
+version = "2023.12.12"
 description = "A tool to wave at the TIDAL music service."
 authors = [
     {name = "colinho", email = "pypi@colin.technology"}

--- a/tidal_wave/album.py
+++ b/tidal_wave/album.py
@@ -7,6 +7,7 @@ from typing import List, Optional
 from requests import Session
 
 from .media import AudioFormat
+from .models import AlbumsEndpointResponseJSON
 from .requesting import request_albums, request_album_items, request_album_review
 from .track import Track
 from .utils import download_cover_image, sleep_to_mimic_human_activity
@@ -97,8 +98,18 @@ class Album:
     def dump(self, fp=sys.stdout):
         json.dump(self.track_files, fp)
 
-    def get(self, session: Session, audio_format: AudioFormat, out_dir: Path):
-        self.get_metadata(session)
+    def get(
+        self,
+        session: Session,
+        audio_format: AudioFormat,
+        out_dir: Path,
+        metadata: Optional[AlbumsEndpointResponseJSON] = None,
+    ):
+        if metadata is None:
+            self.get_metadata(session)
+        else:
+            self.metadata = metadata
+
         self.get_items(session)
         self.save_cover_image(session, out_dir)
         self.get_review(session)

--- a/tidal_wave/artist.py
+++ b/tidal_wave/artist.py
@@ -1,0 +1,138 @@
+from dataclasses import dataclass, field
+import json
+import logging
+from pathlib import Path
+import shutil
+import sys
+from types import SimpleNamespace
+from typing import Dict, List, Optional, Tuple, Union
+
+from requests import HTTPError, Session
+
+from .album import Album
+from .media import AudioFormat
+from .requesting import (
+    request_artists,
+    request_artists_albums,
+    request_artists_audio_works,
+    request_artists_videos,
+)
+from .track import Track
+from .utils import download_cover_image, sleep_to_mimic_human_activity, TIDAL_API_URL
+from .video import Video
+
+logger = logging.getLogger("__name__")
+
+
+@dataclass
+class Artist:
+    artist_id: int
+
+    def __post_init__(self):
+        pass
+
+    def set_metadata(self, session: Session):
+        """This function requests from TIDAL API endpoint /artists and
+        stores the results in self.metadata"""
+        self.metadata: Optional[ArtistsEndpointResponseJSON] = request_artists(
+            session=session, identifier=self.artist_id
+        )
+
+    def save_artist_image(self, session: Session):
+        artist_image: Path = self.artist_dir / "cover.jpg"
+        if not artist_image.exists():
+            download_cover_image(
+                session, self.metadata.picture, self.artist_dir, dimension=750
+            )
+
+    def set_albums(self, session: Session):
+        """This function requests from TIDAL API endpoint /artists/albums and
+        stores the results in self.albums"""
+        self.albums: Optional[ArtistsAlbumsResponseJSON] = request_artists_albums(
+            session=session, identifier=self.artist_id
+        )
+
+    def set_audio_works(self, session: Session):
+        """This function requests from TIDAL API endpoint
+        /artists/albums?filter=EPSANDSINGLES and stores the results in self.albums"""
+        self.albums: Optional[ArtistsAlbumsResponseJSON] = request_artists_audio_works(
+            session=session, identifier=self.artist_id
+        )
+
+    def set_videos(self, session: Session):
+        """This function requests from TIDAL API endpoint /artists/videos and
+        stores the results in self.albums"""
+        self.videos: Optional[ArtistsVideosResponseJSON] = request_artists_videos(
+            session=session, identifier=self.artist_id
+        )
+
+    def set_dir(self, out_dir: Path):
+        """This method sets self.artist_dir and creates the directory on the file system
+        if it does not exist"""
+        self.artist_dir = out_dir / self.metadata.name
+        self.artist_dir.mkdir(parents=True, exist_ok=True)
+
+    def get_albums(
+        self,
+        session: Session,
+        audio_format: AudioFormat,
+        out_dir: Path,
+        include_eps_singles: bool = False,
+    ) -> List[Optional[str]]:
+        if include_eps_singles:
+            self.set_audio_works(session)
+            logger.info(
+                f"Starting attempt to get {self.albums.total_number_of_items} "
+                "albums, EPs, and singles for artist with ID "
+                f"{self.metadata.id},  '{self.metadata.name}'"
+            )
+        else:
+            self.set_albums(session)
+            logger.info(
+                f"Starting attempt to get {self.albums.total_number_of_items} albums "
+                f"for artist with ID {self.metadata.id}, '{self.metadata.name}'"
+            )
+
+        for i, a in enumerate(self.albums.items):
+            album: Album = Album(album_id=a.id)
+            album.get(
+                session=session,
+                audio_format=audio_format,
+                out_dir=out_dir,
+                metadata=a,
+            )
+
+    def get_videos(
+        self,
+        session: Session,
+        out_dir: Path,
+    ) -> List[Optional[str]]:
+        """This method sets self.videos by calling self.set_videos()
+        then, for each video, instantiates a Video object and executes
+        video.get()"""
+        self.set_videos(session)
+        logger.info(
+            f"Starting attempt to get {self.videos.total_number_of_items} videos "
+            f"for artist with ID {self.metadata.id}, '{self.metadata.name}'"
+        )
+        for i, v in enumerate(self.videos.items):
+            video: Video = Video(video_id=v.id)
+            video.get(
+                session=session,
+                out_dir=out_dir,
+                metadata=v,
+            )
+            sleep_to_mimic_human_activity()
+
+    def get(
+        self,
+        session: Session,
+        audio_format: AudioFormat,
+        out_dir: Path,
+        include_eps_singles: bool,
+    ):
+        self.set_metadata(session)
+        self.set_dir(out_dir)
+        self.save_artist_image(session)
+        # self.get_videos(session, out_dir)
+        self.get_albums(session, audio_format, out_dir, include_eps_singles)

--- a/tidal_wave/main.py
+++ b/tidal_wave/main.py
@@ -9,6 +9,7 @@ from typing import Optional
 
 from .login import login, AudioFormat, LogLevel
 from .album import Album
+from .artist import Artist
 from .mix import Mix
 from .playlist import Playlist
 from .track import Track
@@ -16,6 +17,7 @@ from .video import Video
 from .models import (
     match_tidal_url,
     TidalAlbum,
+    TidalArtist,
     TidalMix,
     TidalPlaylist,
     TidalTrack,
@@ -48,6 +50,13 @@ def main(
     loglevel: Annotated[
         LogLevel, typer.Option(case_sensitive=False)
     ] = LogLevel.info.value,
+    include_eps_singles: Annotated[
+        bool,
+        typer.Option(
+            "--include-eps-singles",
+            help="No-op unless passing TIDAL artist. Whether to include artist's EPs and singles with albums",
+        ),
+    ] = False,
 ):
     logging.basicConfig(
         format="%(asctime)s,%(msecs)03d %(levelname)-8s [%(filename)s:%(lineno)d] %(message)s",
@@ -88,6 +97,15 @@ def main(
 
             if loglevel == LogLevel.debug:
                 album.dump()
+            raise typer.Exit(code=0)
+        elif isinstance(tidal_resource, TidalArtist):
+            artist = Artist(artist_id=tidal_resource.tidal_id)
+            artist.get(
+                session=session,
+                audio_format=audio_format,
+                out_dir=output_directory,
+                include_eps_singles=include_eps_singles,
+            )
             raise typer.Exit(code=0)
         elif isinstance(tidal_resource, TidalVideo):
             video = Video(video_id=tidal_resource.tidal_id)

--- a/tidal_wave/requesting.py
+++ b/tidal_wave/requesting.py
@@ -6,7 +6,10 @@ from .models import (
     AlbumsEndpointResponseJSON,
     AlbumsItemsResponseJSON,
     AlbumsReviewResponseJSON,
+    ArtistsAlbumsResponseJSON,
     ArtistsBioResponseJSON,
+    ArtistsEndpointResponseJSON,
+    ArtistsVideosResponseJSON,
     PlaylistsEndpointResponseJSON,
     SessionsEndpointResponseJSON,
     SubscriptionEndpointResponseJSON,
@@ -28,7 +31,10 @@ ResponseJSON = Union[
     AlbumsEndpointResponseJSON,
     AlbumsItemsResponseJSON,
     AlbumsReviewResponseJSON,
+    ArtistsAlbumsResponseJSON,
     ArtistsBioResponseJSON,
+    ArtistsEndpointResponseJSON,
+    ArtistsVideosResponseJSON,
     PlaylistsEndpointResponseJSON,
     SessionsEndpointResponseJSON,
     SubscriptionEndpointResponseJSON,
@@ -144,6 +150,46 @@ request_artist_bio: Callable[
     headers={"Accept": "application/json"},
     url_end="/bio",
     subclass=ArtistsBioResponseJSON,
+)
+
+request_artists: Callable[
+    [Session, int], Optional[ArtistsEndpointResponseJSON]
+] = partial(
+    requester_maker,
+    endpoint="artists",
+    headers={"Accept": "application/json"},
+    subclass=ArtistsEndpointResponseJSON,
+)
+
+request_artists_albums: Callable[
+    [Session, int], Optional[ArtistsAlbumsResponseJSON]
+] = partial(
+    requester_maker,
+    endpoint="artists",
+    headers={"Accept": "application/json"},
+    url_end="/albums",
+    subclass=ArtistsAlbumsResponseJSON,
+)
+
+request_artists_audio_works: Callable[
+    [Session, int], Optional[ArtistsAlbumsResponseJSON]
+] = partial(
+    requester_maker,
+    endpoint="artists",
+    headers={"Accept": "application/json"},
+    parameters={"filter": "EPSANDSINGLES"},
+    url_end="/albums",
+    subclass=ArtistsAlbumsResponseJSON,
+)
+
+request_artists_videos: Callable[
+    [Session, int], Optional[ArtistsAlbumsResponseJSON]
+] = partial(
+    requester_maker,
+    endpoint="artists",
+    headers={"Accept": "application/json"},
+    url_end="/videos",
+    subclass=ArtistsVideosResponseJSON,
 )
 
 request_tracks: Callable[


### PR DESCRIPTION
Edit README.md with new examples and explantion of the new feature

New file, `artist.py`, that drives the program behavior when a TIDAL artist URL is passed

Add the option for `album.Album.get()` to accept metadata as argument

Requisite additions in `main.py`, `models.py`, and `requesting.py` 