### PR TITLE
Hotifx: change country_code to countryCode in login.py

### DIFF
--- a/tidal_wave/login.py
+++ b/tidal_wave/login.py
@@ -207,7 +207,7 @@ def login_windows(
             "session_id": s.session_id,
             "client_id": s.client_id,
             "client_name": s.client_name,
-            "country_code": s.params["country_code"],
+            "country_code": s.params["countryCode"],
         }
         token_path.write_bytes(base64.b64encode(bytes(json.dumps(to_write), "UTF-8")))
     return s


### PR DESCRIPTION
In line 210 of login.py, the session parameter `countryCode` was incorrectly specified as `country_code` causing program crash.