### PR TITLE
Handle album 404

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -24,6 +24,9 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v4
 
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v3
+      
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v3
 
@@ -47,5 +50,6 @@ jobs:
         push: true
         cache-from: type=gha
         cache-to: type=gha,mode=max
+        platforms: linux/amd64, linux/arm64
         tags: ${{ steps.meta.outputs.tags }}
         labels: ${{ steps.meta.outputs.labels }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,6 +31,7 @@ LABEL org.opencontainers.image.authors "colinho <github@colin.technology>"
 LABEL org.opencontainers.image.description "Waving at the TIDAL music service with Python"
 LABEL org.opencontainers.image.documentation "https://github.com/ebb-earl-co/tidal-wave/blob/trunk/README.md"
 LABEL org.opencontainers.image.source "https://github.com/ebb-earl-co/tidal-wave"
+LABEL org.opencontainers.image.licenses "LGPL-2.1-only AND Apache-2.0"
 
 ENV PIP_DEFAULT_TIMEOUT=100 \
     # Allow statements and log messages to immediately appear

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ requires = ["setuptools", "wheel"]
 universal = 0  # Make the generated wheels have "py3" tag
 [project]
 name = "tidal-wave"
-version = "2024.1.9"
+version = "2024.1.10"
 description = "A tool to wave at the TIDAL music service."
 authors = [
     {name = "colinho", email = "pypi@colin.technology"}

--- a/tidal_wave/album.py
+++ b/tidal_wave/album.py
@@ -137,6 +137,10 @@ class Album:
             self.get_metadata(session)
         else:
             self.metadata = metadata
+        
+        if self.metadata is None:
+            self.track_files = {}
+            return
 
         self.get_items(session)
         self.save_cover_image(session, out_dir)

--- a/tidal_wave/artist.py
+++ b/tidal_wave/artist.py
@@ -143,6 +143,10 @@ class Artist:
             5. get_albums
         """
         self.set_metadata(session)
+        
+        if self.metadata is None:
+            return
+        
         self.set_dir(out_dir)
         self.save_artist_image(session)
         self.get_videos(session, out_dir)

--- a/tidal_wave/mix.py
+++ b/tidal_wave/mix.py
@@ -38,6 +38,10 @@ class Mix:
         self.metadata: Optional[PlaylistsEndpointResponseJSON] = request_mixes(
             session=session, mix_id=self.mix_id
         )
+        
+        if self.metadata is None:
+            return
+        
         self.name = (
             self.metadata.title.replace("/", "_")
             .replace("|", "_")
@@ -233,6 +237,11 @@ class Mix:
           - self.flatten_playlist_dir()
         """
         self.get_metadata(session)
+        
+        if self.metadata is None:
+            self.files = {}
+            return
+        
         self.set_items(session)
         self.set_dir(out_dir)
         self.save_cover_image(session, out_dir)

--- a/tidal_wave/playlist.py
+++ b/tidal_wave/playlist.py
@@ -39,6 +39,10 @@ class Playlist:
         self.metadata: Optional[PlaylistsEndpointResponseJSON] = request_playlists(
             session=session, identifier=self.playlist_id
         )
+        
+        if self.metadata is None:
+            return
+        
         self.name = (
             self.metadata.title.replace("/", "_")
             .replace("|", "_")
@@ -297,6 +301,11 @@ class Playlist:
           - self.flatten_playlist_dir()
         """
         self.get_metadata(session)
+    
+        if self.metadata is None:
+            self.files = {}
+            return
+        
         self.set_items(session)
         self.set_dir(out_dir)
         self.save_cover_image(session, out_dir)

--- a/tidal_wave/track.py
+++ b/tidal_wave/track.py
@@ -463,7 +463,6 @@ class Track:
             self.metadata = metadata
 
         if self.metadata is None:
-            # self.failed = True
             self.outfile = None
             return
 

--- a/tidal_wave/video.py
+++ b/tidal_wave/video.py
@@ -203,7 +203,6 @@ class Video:
         else:
             self.metadata = metadata
 
-        # check for 404 error with metadata
         if self.metadata is None:
             return None
 


### PR DESCRIPTION
The main purpose of this PR is to add short-circuit `return`s in the `get_metadata()` method of the various TIDAL media classes. This is because hitting a 404 of the album/artist/mix/playlist/track/video cascaded errors in the subsequent steps (see #49) and that's just not good programming.