### PR TITLE
Rejigger Dockerfile

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -54,4 +54,9 @@ jobs:
         cache-to: type=gha,mode=max
         platforms: linux/amd64, linux/arm64
         tags: ${{ steps.meta.outputs.tags }}
-        labels: ${{ steps.meta.outputs.labels }}
+        labels: |
+          org.opencontainers.image.authors "colinho <github@colin.technology>"
+          org.opencontainers.image.description "Waving at the TIDAL music service with Python"
+          org.opencontainers.image.documentation "https://github.com/ebb-earl-co/tidal-wave/blob/trunk/README.md"
+          org.opencontainers.image.source "https://github.com/ebb-earl-co/tidal-wave"
+          org.opencontainers.image.licenses "LGPL-2.1-only"

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -55,8 +55,8 @@ jobs:
         platforms: linux/amd64, linux/arm64
         tags: ${{ steps.meta.outputs.tags }}
         labels: |
-          org.opencontainers.image.authors "colinho <github@colin.technology>"
-          org.opencontainers.image.description "Waving at the TIDAL music service with Python"
-          org.opencontainers.image.documentation "https://github.com/ebb-earl-co/tidal-wave/blob/trunk/README.md"
-          org.opencontainers.image.source "https://github.com/ebb-earl-co/tidal-wave"
-          org.opencontainers.image.licenses "LGPL-2.1-only"
+          org.opencontainers.image.authors="colinho <github@colin.technology>"
+          org.opencontainers.image.description="Waving at the TIDAL music service with Python"
+          org.opencontainers.image.documentation="https://github.com/ebb-earl-co/tidal-wave/blob/trunk/README.md"
+          org.opencontainers.image.source="https://github.com/ebb-earl-co/tidal-wave"
+          org.opencontainers.image.licenses="LGPL-2.1-only"

--- a/Dockerfile
+++ b/Dockerfile
@@ -52,16 +52,13 @@ RUN useradd --create-home --shell /bin/bash debian
 COPY --from=build_image --chown=debian:debian /root/bin/ffmpeg /usr/local/bin/ffmpeg
 USER debian
 WORKDIR /home/debian
-COPY --chown=debian:debian pyproject.toml .
-COPY --chown=debian:debian setup.py .
-COPY --chown=debian:debian README.md .
-COPY --chown=debian:debian LICENSE .
+COPY --chown=debian:debian requirements.txt .
 COPY --chown=debian:debian tidal_wave/ ./tidal_wave/
 RUN pip install --user --upgrade pip setuptools wheel dumb-init && \
-    pip install --user .[all] && \
+    pip install --user -r requirements.txt && \
     mkdir -p /home/debian/.config/tidal-wave/ /home/debian/Music/ && \
     chown -R debian:debian /home/debian/.config/tidal-wave/ /home/debian/Music/
 ENV PATH="/home/debian/.local/bin:$PATH"
 VOLUME /home/debian/.config/tidal-wave /home/debian/Music
-ENTRYPOINT ["dumb-init", "--", "tidal-wave"]
+ENTRYPOINT ["dumb-init", "--", "python3", "-m", "tidal_wave"]
 CMD ["--help"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -63,4 +63,5 @@ RUN pip install --user --upgrade pip setuptools wheel dumb-init && \
     chown -R debian:debian /home/debian/.config/tidal-wave/ /home/debian/Music/
 ENV PATH="/home/debian/.local/bin:$PATH"
 VOLUME /home/debian/.config/tidal-wave /home/debian/Music
-ENTRYPOINT ["dumb-init", "--"]
+ENTRYPOINT ["dumb-init", "--", "tidal-wave"]
+CMD ["--help"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ classifiers=[
 ]
 dependencies = [
     "backoff==2.2.1",
-    "dataclass-wizard==0.22.2",
+    "dataclass-wizard==0.22.3",
     "ffmpeg-python==0.2.0",
     "mutagen==1.47.0",
     "m3u8==4.0.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ dependencies = [
     "ffmpeg-python==0.2.0",
     "mutagen==1.47.0",
     "m3u8==4.0.0",
-    "platformdirs==4.1.0",
+    "platformdirs==4.2.0",
     "requests==2.31.0",
     "typer==0.9.0"
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 backoff==2.2.1
-dataclass-wizard==0.22.2
+dataclass-wizard==0.22.3
 ffmpeg-python==0.2.0
 mutagen==1.47.0
 m3u8==4.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,6 @@ dataclass-wizard==0.22.3
 ffmpeg-python==0.2.0
 mutagen==1.47.0
 m3u8==4.0.0
-platformdirs==4.1.0
+platformdirs==4.2.0
 requests==2.31.0
 typer==0.9.0


### PR DESCRIPTION
Spurred by #63 , this pull request brings in changes to how Docker images are build and used:

- First of all, after having read some blogs and opinion pieces, the process supervisor [`dumb-init`](https://github.com/Yelp/dumb-init) is used as the `ENTRYPOINT` in Dockerfile, mainly because it is available from PyPi and the rest of Dockerfile is Python-themed.
- By default, running `$ docker run --rm -it tidal-wave:latest` will execute `tidal-wave --help`, printing the help dialog of the Python program and exiting, similar to previous behavior
- Passing arguments to `docker run` is just like passing them to `tidal-wave` without Docker; a helpful alias to set up might be `$ alias tidalwave='docker run --name=tidal-wave --rm -it --volume ~/Music:/home/debian/Music --volume ~/.config/tidal-wave:/home/debian/.config/tidal-wave ghcr.io/ebb-earl-co/tidal-wave:latest'`. Using this would be *essentially identical* to non-Docker Python invocation.
- In order to have a long-running container for repeated execution, only two small changes to the above need be made: `$ docker run --name=tidal-wave -dit --volume ~/Music:/home/debian/Music --volume ~/.config/tidal-wave:/home/debian/.config/tidal-wave --entrypoint="/bin/bash" ghcr.io/ebb-earl-co/tidal-wave:latest`
What this will do is start a container named `tidal-wave` that runs in the background (`-d`), and, instead of executing the Python program `tidal-wave` and exiting, it executes `/bin/bash`, a shell in the container. From here, one would execute the `tidal-wave` Python program logic by using `docker exec`, like so:
`$ docker exec -it tidal-wave 'tidal-wave https://listen.tidal.com/... ...'`