### PR TITLE
Add CLI flag --no-flatten to control Playlist and Mix behavior

### DIFF
--- a/tidal_wave/main.py
+++ b/tidal_wave/main.py
@@ -61,6 +61,13 @@ def main(
             help="Whether to not even attempt to retrieve artist bio, artist image, album review, or playlist m3u8",
         ),
     ] = False,
+    no_flatten: Annotated[
+        bool,
+        typer.Option(
+            "--no-flatten",
+            help="Whether to treat playlists or mixes as a list of tracks/videos and, as such, retrieve them independently",
+        ),
+    ] = False,
 ):
     logging.basicConfig(
         format="%(asctime)s,%(msecs)03d %(levelname)-8s [%(filename)s:%(lineno)d] %(message)s",
@@ -127,24 +134,40 @@ def main(
             raise typer.Exit(code=0)
         elif isinstance(tidal_resource, TidalPlaylist):
             playlist = Playlist(playlist_id=tidal_resource.tidal_id)
-            playlist.get(
-                session=session,
-                audio_format=audio_format,
-                out_dir=output_directory,
-                no_extra_files=no_extra_files,
-            )
+            if no_flatten:
+                playlist.get_elements(
+                    session=session,
+                    audio_format=audio_format,
+                    out_dir=output_directory,
+                    no_extra_files=no_extra_files,
+                )
+            else:
+                playlist.get(
+                    session=session,
+                    audio_format=audio_format,
+                    out_dir=output_directory,
+                    no_extra_files=no_extra_files,
+                )
 
             if loglevel == LogLevel.debug:
                 playlist.dump()
             raise typer.Exit(code=0)
         elif isinstance(tidal_resource, TidalMix):
             mix = Mix(mix_id=tidal_resource.tidal_id)
-            mix.get(
-                session=session,
-                audio_format=audio_format,
-                out_dir=output_directory,
-                no_extra_files=no_extra_files,
-            )
+            if no_flatten:
+                mix.get_elements(
+                    session=session,
+                    audio_format=audio_format,
+                    out_dir=output_directory,
+                    no_extra_files=no_extra_files,
+                )
+            else:
+                mix.get(
+                    session=session,
+                    audio_format=audio_format,
+                    out_dir=output_directory,
+                    no_extra_files=no_extra_files,
+                )
 
             if loglevel == LogLevel.debug:
                 mix.dump()

--- a/tidal_wave/video.py
+++ b/tidal_wave/video.py
@@ -233,6 +233,8 @@ class Video:
         outfile: Optional[Path] = self.set_outfile()
         if outfile is None:
             return None
+        else:
+            self.absolute_outfile = str(self.outfile.absolute())
 
         if self.download(session, out_dir) is None:
             return None
@@ -240,7 +242,7 @@ class Video:
         return str(self.outfile.absolute())
 
     def dump(self, fp=sys.stdout):
-        json.dump({self.metadata.title: str(self.outfile.absolute())}, fp)
+        json.dump({self.metadata.title: self.absolute_outfile}, fp)
 
     def dumps(self) -> str:
-        return json.dumps({self.metadata.title: str(self.outfile.absolute())})
+        return json.dumps({self.metadata.title: self.absolute_outfile})


### PR DESCRIPTION
Based on feature request from #63, add a top-level CLI flag to `tidal-wave`. This flag, `--no-flatten`, is a no-op for everything *but* playlists and mixes.

By default (and, up to this point), when a playlist or mix URL is passed to `tidal-wave`, the program retrieves all the tracks and/or videos specified by the mix/playlist and then moves all the media to a subdirectory of either `Playlists` or `Mixes` which itself is a subdirectory of the output directory passed to `tidal-wave`. Then, the media that have just been moved are renamed, specifying the order that they appear in the playlist, padded to three digits. For example, take this mix generated by TIDAL
![image](https://github.com/ebb-earl-co/tidal-wave/assets/11299014/07ce22e0-e304-45b0-97a8-86a31aecc9dd)

The first track, "Where You Are" is the first track in its album, "Where You Are", so the track is originally downloaded to `~/Music/John Summit/Where You Are [278684344] [2023]/01 - Where You Are [CD].flac`. Whereas the default Mix behavior is to move this track to `~/Music/Mixes/My Daily Discovery [016dccd302e9ac6132d8334cfbc022]/001 - Where You Are [CD].flac`, this pull request adds the option to leave the track where it was downloaded first.