### PR TITLE
HOTFIX: Stream Manifest Parsing for Windows Access Token Responses

### DIFF
--- a/tidal_wave/dash.py
+++ b/tidal_wave/dash.py
@@ -133,8 +133,8 @@ def manifester(tesrj: TracksEndpointStreamResponseJSON) -> Manifest:
                     )
                 else:
                     return manifest
-        elif tesrj.audio_mode == "STEREO" and tesrj.audio_quality == "HI_RES":
-            # Dealing with MQA here
+        elif tesrj.audio_mode == "STEREO":
+            # Dealing with MQA here or any quality responding to Windows access token
             try:
                 manifest: Manifest = dataclass_wizard.fromdict(
                     JSONDASHManifest, json.loads(tesrj.manifest_bytes)
@@ -174,8 +174,8 @@ def manifester(tesrj: TracksEndpointStreamResponseJSON) -> Manifest:
                     return manifest
         else:
             raise TidalManifestException(
-                "Expected a manifest for Dolby Atmos, MQA, or Sony 360 Reality Audio "
-                f"for track {tesrj.track_id}"
+                "Expected a manifest of Dolby Atmos, MQA, Sony 360 Reality Audio, "
+                f"or encrypted-for-Windows-client audio for track {tesrj.track_id}"
             )
     elif tesrj.manifest_mime_type == "application/dash+xml":
         try:

--- a/tidal_wave/login.py
+++ b/tidal_wave/login.py
@@ -192,7 +192,7 @@ def login_windows(
     token_path: Path = TOKEN_DIR_PATH / "windows-tidal.token",
 ) -> Optional[requests.Session]:
     _token: Optional[dict] = load_token_from_disk(token_path=token_path)
-    access_token: Optional[str] = _token.get("access_token")
+    access_token: Optional[str] = None if _token is None else _token.get("access_token")
     if access_token is None:
         access_token: str = typer.prompt(
             "Enter Tidal API access token (the part after 'Bearer ')"
@@ -203,7 +203,7 @@ def login_windows(
         logger.critical("Access token is not valid: exiting now.")
     else:
         logger.debug(f"Writing this access token to '{str(token_path.absolute())}'")
-        s.headers["User-Agent"] = "TIDAL_NATIVE_PLAYER/WIN/3.1.2.195"
+        s.headers["User-Agent"] = "Mozilla/5.0 (Windows NT 10.0; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) TIDAL/2.36.2 Chrome/116.0.5845.228 Electron/26.6.1 Safari/537.36"
         s.params["deviceType"] = "DESKTOP"
         to_write: dict = {
             "access_token": s.auth.token,


### PR DESCRIPTION
Incorporate the suggestion in #89, fixing a hole in `login.login_windows()`. This should close #88, laying the groundwork to fix #88 