### PR TITLE
Add Sanitization of Track Version String

### DIFF
--- a/tidal_wave/models.py
+++ b/tidal_wave/models.py
@@ -138,7 +138,8 @@ class TracksEndpointResponseJSON(dataclass_wizard.JSONWizard):
 
     def __post_init__(self):
         name: str = replace_illegal_characters(self.title)
-        self.name: str = name if self.version is None else f"{name} ({self.version})"
+        version: str = replace_illegal_characters(self.version)
+        self.name: str = name if self.version is None else f"{name} ({version})"
 
 
 @dataclass


### PR DESCRIPTION
Up until this point, track *names* have been sanitized, removing illegal characters on Windows. This overlooked the track *version* substring, so this pull request adds sanitization of that