### PR TITLE
Introduce HTTP Cache-Control and Update GitHub Actions

### DIFF
--- a/.github/workflows/pyapp-linux.yml
+++ b/.github/workflows/pyapp-linux.yml
@@ -4,10 +4,12 @@ on:
     types: ["published"]
 
 env:
+  PYAPP_DISTRIBUTION_EMBED: 1
+  PYAPP_METADATA_TEMPLATE: "{project}, version {version}"
+  PYAPP_PROJECT_FEATURES: "all"
   PYAPP_PROJECT_NAME: "tidal-wave"
   PYAPP_PROJECT_VERSION: ${{ github.event.release.tag_name }}
-  PYAPP_DISTRIBUTION_EMBED: 1
-  PYAPP_PYTHON_VERSION: 3.11
+  PYAPP_PYTHON_VERSION: "3.11"
 
 permissions:
   contents: write
@@ -24,11 +26,22 @@ jobs:
         with:
           crate: pyapp
           version: 0.16.0
+          args: "--root ~/.cargo"
+      
+      - name: Upload artifact
+        id: artifact-upload-step
+        uses: actions/upload-artifact@v4
+        with:
+          name: tidal-wave_${{ github.event.release.tag_name }}_py311.pyapp
+          path: ~/.cargo/bin/pyapp
+          compression-level: 0
+          if-no-files-found: error
+          retention-days: 1
 
       - name: Rename just-compiled binary
         shell: bash
         run: |
-          mv /home/runner/.cargo-install/pyapp/bin/pyapp ${{ github.workspace }}/tidal-wave_py311.pyapp
+          mv ~/.cargo/bin/pyapp ${{ github.workspace }}/tidal-wave_py311.pyapp
 
       - name: Test just-compiled binary
         run: |

--- a/.github/workflows/pyapp-macos_arm64.yml
+++ b/.github/workflows/pyapp-macos_arm64.yml
@@ -4,10 +4,12 @@ on:
     types: ["published"]
 
 env:
+  PYAPP_DISTRIBUTION_EMBED: 1
+  PYAPP_METADATA_TEMPLATE: "{project}, version {version}"
+  PYAPP_PROJECT_FEATURES: "all"
   PYAPP_PROJECT_NAME: "tidal-wave"
   PYAPP_PROJECT_VERSION: ${{ github.event.release.tag_name }}
-  PYAPP_DISTRIBUTION_EMBED: 1
-  PYAPP_PYTHON_VERSION: 3.11
+  PYAPP_PYTHON_VERSION: "3.11"
   # https://doc.rust-lang.org/cargo/reference/config.html#buildtarget
   CARGO_BUILD_TARGET: "aarch64-apple-darwin"
 
@@ -26,10 +28,21 @@ jobs:
         with:
           crate: pyapp
           version: 0.16.0
+          args: "--root ~/.cargo"
+
+      - name: Upload artifact
+        id: artifact-upload-step
+        uses: actions/upload-artifact@v4
+        with:
+          name: tidal-wave_${{ github.event.release.tag_name }}_py311_macos_arm64.pyapp
+          path: ~/.cargo/bin/pyapp
+          compression-level: 0
+          if-no-files-found: error
+          retention-days: 1
 
       - name: Rename just-compiled binary
         run: |
-          mv /Users/runner/.cargo-install/pyapp/bin/pyapp ${{ github.workspace }}/tidal-wave_py311_macos_arm64.pyapp
+          mv ~/.cargo/bin/pyapp ${{ github.workspace }}/tidal-wave_py311_macos_arm64.pyapp
 
       - name: Test just-compiled binary
         run: ${{ github.workspace }}/tidal-wave_py311_macos_arm64.pyapp --help

--- a/.github/workflows/pyapp-macos_x86.yml
+++ b/.github/workflows/pyapp-macos_x86.yml
@@ -4,9 +4,11 @@ on:
     types: ["published"]
 
 env:
+  PYAPP_DISTRIBUTION_EMBED: 1
+  PYAPP_METADATA_TEMPLATE: "{project}, version {version}"
+  PYAPP_PROJECT_FEATURES: "all"
   PYAPP_PROJECT_NAME: "tidal-wave"
   PYAPP_PROJECT_VERSION: ${{ github.event.release.tag_name }}
-  PYAPP_DISTRIBUTION_EMBED: 1
   PYAPP_PYTHON_VERSION: "3.11"
   # https://doc.rust-lang.org/cargo/reference/config.html#buildtarget
   CARGO_BUILD_TARGET: "x86_64-apple-darwin"
@@ -26,6 +28,17 @@ jobs:
         with:
           crate: pyapp
           version: 0.16.0
+          args: "--root ~/.cargo"
+
+      - name: Upload artifact
+        id: artifact-upload-step
+        uses: actions/upload-artifact@v4
+        with:
+          name: tidal-wave_${{ github.event.release.tag_name }}_py311_macos.pyapp
+          path: ~/.cargo/bin/pyapp
+          compression-level: 0
+          if-no-files-found: error
+          retention-days: 1
 
       - name: Rename just-compiled binary
         run: |

--- a/.github/workflows/pyapp-windows.yml
+++ b/.github/workflows/pyapp-windows.yml
@@ -4,9 +4,11 @@ on:
     types: ["published"]
 
 env:
+  PYAPP_DISTRIBUTION_EMBED: 1
+  PYAPP_METADATA_TEMPLATE: "{project}, version {version}"
+  PYAPP_PROJECT_FEATURES: "all"
   PYAPP_PROJECT_NAME: "tidal-wave"
   PYAPP_PROJECT_VERSION: ${{ github.event.release.tag_name }}
-  PYAPP_DISTRIBUTION_EMBED: 1
   PYAPP_PYTHON_VERSION: "3.11"
 
 permissions:
@@ -24,26 +26,27 @@ jobs:
         with:
           crate: pyapp
           version: 0.16.0
-
-      - name: Test just-compiled binary
-        shell: pwsh
-        run: |
-          & "C:\Users\runneradmin\.cargo-install\pyapp\bin\pyapp.exe" --help
-
-      - name: Rename just-compiled EXE
-        shell: pwsh
-        run: |
-          Move-Item "C:\Users\runneradmin\.cargo-install\pyapp\bin\pyapp.exe" ${{ github.workspace }}\tidal-wave_py311_pyapp.exe
+          args: "--root C:\\Users\\runneradmin\\.cargo"
 
       - name: Upload artifact
         id: artifact-upload-step
         uses: actions/upload-artifact@v4
         with:
           name: tidal-wave_${{ github.event.release.tag_name }}_py311_pyapp.exe
-          path: ${{ github.workspace }}\tidal-wave_py311_pyapp.exe
+          path: C:\Users\runneradmin\.cargo\bin\pyapp.exe
           compression-level: 0
           if-no-files-found: error
           retention-days: 1
+
+      - name: Test just-compiled binary
+        shell: pwsh
+        run: |
+          & "C:\Users\runneradmin\.cargo\bin\pyapp.exe" --help
+
+      - name: Rename just-compiled EXE
+        shell: pwsh
+        run: |
+          Move-Item "C:\Users\runneradmin\.cargo\bin\pyapp.exe" ${{ github.workspace }}\tidal-wave_py311_pyapp.exe
 
       - name: Add artifact to release
         uses: softprops/action-gh-release@v2

--- a/.github/workflows/pyinstaller-macos_arm64.yml
+++ b/.github/workflows/pyinstaller-macos_arm64.yml
@@ -48,6 +48,7 @@ jobs:
           mkdir -p ~/ffmpeg_build/ ~/bin/
           cd FFmpeg-6.1.1
           PATH="$HOME/bin:$PATH" PKG_CONFIG_PATH="$HOME/ffmpeg_build/lib/pkgconfig" ./configure \
+            --arch=arm64 \
             --prefix="$HOME/ffmpeg_build" \
             --pkg-config-flags="--static" \
             --ld="g++" \

--- a/.github/workflows/pyinstaller-macos_x86.yml
+++ b/.github/workflows/pyinstaller-macos_x86.yml
@@ -47,6 +47,7 @@ jobs:
           mkdir -p ~/ffmpeg_build/ ~/bin/
           cd FFmpeg-6.1.1
           PATH="$HOME/bin:$PATH" PKG_CONFIG_PATH="$HOME/ffmpeg_build/lib/pkgconfig" ./configure \
+            --arch=x86_64 \
             --prefix="$HOME/ffmpeg_build" \
             --pkg-config-flags="--static" \
             --ld="g++" \

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ This software uses libraries from the [FFmpeg](http://ffmpeg.org) project under 
 * Mix retrieval support (video or audio)
 * Artist's entire works retrieval support (video and audio; albums or albums and EPs and singles)
 * Because of the use of the `requests` package, system proxies are respected (HTTP, HTTPs, Socks); or can be specified by typical environment variable
+* Also because of the use of `requests`, very simple [`Cache-Control`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control) request caching occurs via `CacheControl`
 
 ## Getting Started
 A [HiFi Plus](https://tidal.com/pricing) account is **required** in order to retrieve HiRes FLAC, Dolby Atmos, and Sony 360 Reality Audio tracks. Simply a [HiFi](https://tidal.com/pricing) plan is sufficient to retrieve in 16-bit, 44.1 kHz (i.e., lossless) or lower quality as well as videos. More information on sound quality at [TIDAL's site here](https://tidal.com/sound-quality).
@@ -42,6 +43,7 @@ A [HiFi Plus](https://tidal.com/pricing) account is **required** in order to ret
    - *However*, as of December 2023, an [OCI container image](https://github.com/ebb-earl-co/tidal-wave/pkgs/container/tidal-wave); `pyapp`-compiled binaries; and [`pyinstaller`](https://pyinstaller.org/en/stable/)-created binaries for x86\_64 GNU/Linux, Apple Silicon macOS, and x86\_64 macOS are provided for download and use that *do not require Python to be installed*
  - Only a handful of Python libraries are dependencies:
    - [`backoff`](https://pypi.org/project/backoff/)
+   - [`cachecontrol`](https://pypi.org/project/CacheControl/)
    - [`dataclass-wizard`](https://pypi.org/project/dataclass-wizard/)
    - [`ffmpeg-python`](https://pypi.org/project/ffmpeg-python/)
    - [`mutagen`](https://pypi.org/project/mutagen/)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ dependencies = [
     "platformdirs==4.2.0",
     "pycryptodome==3.20.0",
     "requests[socks]==2.31.0",
-    "typer==0.10.0"
+    "typer==0.11.0"
 ]
 [project.optional-dependencies]
 all = ["typer[all]==0.10.0"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ classifiers=[
 ]
 dependencies = [
     "backoff==2.2.1",
+    "cachecontrol==0.14.0",
     "dataclass-wizard==0.22.3",
     "ffmpeg-python==0.2.0",
     "mutagen==1.47.0",

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,4 @@ m3u8==4.0.0
 platformdirs==4.2.0
 pycryptodome==3.20.0
 requests[socks]==2.31.0
-typer==0.10.0
+typer==0.11.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 backoff==2.2.1
+cachecontrol==0.14.0
 dataclass-wizard==0.22.3
 ffmpeg-python==0.2.0
 mutagen==1.47.0

--- a/tidal_wave/login.py
+++ b/tidal_wave/login.py
@@ -265,7 +265,7 @@ def login_macos(
         token_path.write_bytes(base64.b64encode(bytes(json.dumps(to_write), "UTF-8")))
     return s
 
-  
+
 def login(
     audio_format: AudioFormat,
 ) -> Tuple[Optional[requests.Session], Union[AudioFormat, str]]:

--- a/tidal_wave/main.py
+++ b/tidal_wave/main.py
@@ -20,6 +20,7 @@ from .models import (
     TidalVideo,
 )
 
+from cachecontrol import CacheControl
 from platformdirs import user_music_path
 import typer
 from typing_extensions import Annotated
@@ -90,7 +91,7 @@ def main(
     if s is None:
         raise typer.Exit(code=1)
 
-    with closing(s) as session:
+    with closing(CacheControl(s)) as session:
         if isinstance(tidal_resource, TidalTrack):
             track = Track(track_id=tidal_resource.tidal_id)
             track.get(


### PR DESCRIPTION
In this pull request:

- Bump the version of dependence `typer` to 0.11.0
- Bump the version of build dependence, Rust library `pyapp`, to 0.16.0
- Upload build artifacts to GitHub Actions cache before renaming and adding to release
- Add `CacheControl` PyPi package to requirements.txt, pyproject.yaml, README.md, and use it in `tidal_wave/main.py`