### PR TITLE
Address Issue #137

### DIFF
--- a/tidal_wave/album.py
+++ b/tidal_wave/album.py
@@ -70,10 +70,10 @@ class Album:
         """This method requests the album's top-level credits (separate from
         each track's credits) and writes them to AlbumCredits.json in
         self.album_dir"""
-        self.album_credits: Optional[
-            AlbumsCreditsResponseJSON
-        ] = request_albums_credits(
-            session=session, album_id=self.album_id, transparent=self.transparent
+        self.album_credits: Optional[AlbumsCreditsResponseJSON] = (
+            request_albums_credits(
+                session=session, album_id=self.album_id, transparent=self.transparent
+            )
         )
         if self.album_credits is not None:
             num_credit: int = len(self.album_credits.credit)

--- a/tidal_wave/album.py
+++ b/tidal_wave/album.py
@@ -76,9 +76,15 @@ class Album:
             session=session, album_id=self.album_id, transparent=self.transparent
         )
         if self.album_credits is not None:
-            f: str = str((self.album_dir / "AlbumCredits.json").absolute())
-            with open(f, "w") as fp:
-                json.dump(obj=self.album_credits.credit, fp=fp)
+            num_credit: int = len(self.album_credits.credit)
+            if num_credit == 0:
+                logger.warning(
+                    f"No album credits returned from TIDAL API for album {self.album_id}"
+                )
+            else:
+                ac_file: str = str((self.album_dir / "AlbumCredits.json").absolute())
+                with open(ac_file, "w") as fp:
+                    json.dump(obj=self.album_credits.credit, fp=fp)
 
     def set_album_dir(self, out_dir: Path):
         """This method populates self.album_dir as a sub-subdirectory of
@@ -91,6 +97,9 @@ class Album:
         )
         self.album_dir = out_dir / artist_substring / album_substring
         self.album_dir.mkdir(parents=True, exist_ok=True)
+        # Create cover_path here, even if the API
+        # does not return a cover, to avoid AttributeError later
+        self.cover_path: Path = self.album_dir / "cover.jpg"
 
         if self.metadata.number_of_volumes > 1:
             for v in range(1, self.metadata.number_of_volumes + 1):
@@ -105,7 +114,6 @@ class Album:
         then self.album_cover_saved takes the value True"""
         if self.album_dir is None:
             self.set_album_dir(out_dir=out_dir)
-        self.cover_path: Path = self.album_dir / "cover.jpg"
         if not self.cover_path.exists():
             download_cover_image(
                 session=session,

--- a/tidal_wave/login.py
+++ b/tidal_wave/login.py
@@ -89,12 +89,12 @@ def validate_token_for_session(
         logger.debug(serj)
 
     sess: requests.Session = requests.Session()
-    sess.headers: Dict[str, str] = headers
-    sess.auth: BearerAuth = BearerAuth(token=token)
-    sess.user_id: str = serj.user_id
-    sess.session_id: str = serj.session_id
-    sess.client_id: str = serj.client.id
-    sess.client_name: str = serj.client.name
+    sess.headers = headers
+    sess.auth = BearerAuth(token=token)
+    sess.user_id = serj.user_id
+    sess.session_id = serj.session_id
+    sess.client_id = serj.client.id
+    sess.client_name = serj.client.name
     if serj.country_code == "US":
         sess.params["countryCode"] = "US"
         sess.params["locale"] = "en_US"
@@ -212,9 +212,9 @@ def login_windows(
             token_path.unlink()
     else:
         logger.debug(f"Writing this access token to '{str(token_path.absolute())}'")
-        s.headers[
-            "User-Agent"
-        ] = "Mozilla/5.0 (Windows NT 10.0; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) TIDAL/2.36.2 Chrome/116.0.5845.228 Electron/26.6.1 Safari/537.36"
+        s.headers["User-Agent"] = (
+            "Mozilla/5.0 (Windows NT 10.0; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) TIDAL/2.36.2 Chrome/116.0.5845.228 Electron/26.6.1 Safari/537.36"
+        )
         s.headers["Origin"] = s.headers["Referer"] = "https://desktop.tidal.com/"
         s.params["deviceType"] = "DESKTOP"
         to_write: dict = {
@@ -249,9 +249,9 @@ def login_macos(
             token_path.unlink()
     else:
         logger.debug(f"Writing this access token to '{str(token_path.absolute())}'")
-        s.headers[
-            "User-Agent"
-        ] = "TIDALPlayer/3.1.4.209 CFNetwork/1494.0.7 Darwin/23.4.0"
+        s.headers["User-Agent"] = (
+            "TIDALPlayer/3.1.4.209 CFNetwork/1494.0.7 Darwin/23.4.0"
+        )
         s.headers["x-tidal-client-version"] = "2024.3.14"
         s.headers["Origin"] = s.headers["Referer"] = "https://desktop.tidal.com/"
         s.params["deviceType"] = "DESKTOP"

--- a/tidal_wave/mix.py
+++ b/tidal_wave/mix.py
@@ -112,9 +112,9 @@ class Mix:
                 tracks_videos[i] = None
                 continue
         else:
-            self.tracks_videos: Tuple[
-                Tuple[int, Optional[Union[Track, Video]]]
-            ] = tuple(tracks_videos)
+            self.tracks_videos: Tuple[Tuple[int, Optional[Union[Track, Video]]]] = (
+                tuple(tracks_videos)
+            )
         return tracks_videos
 
     def flatten_mix_dir(self):

--- a/tidal_wave/models.py
+++ b/tidal_wave/models.py
@@ -211,8 +211,8 @@ class AlbumsCreditsResponseJSON(dataclass_wizard.JSONWizard):
             return
 
     def __post_init__(self):
-        """Try to parse the various Contributors into a dict
-        that will be JSON-format amenable"""
+        """Try to parse the various Contributors into a dict,
+        self.credit, that will be JSON-format amenable"""
 
         _credit: Dict[str, Union[str, List[str]]] = {
             c: self.get_contributors(c)

--- a/tidal_wave/playlist.py
+++ b/tidal_wave/playlist.py
@@ -133,9 +133,9 @@ class Playlist:
                 tracks_videos[i] = None
                 continue
         else:
-            self.tracks_videos: Tuple[
-                Tuple[int, Optional[Union[Track, Video]]]
-            ] = tuple(tracks_videos)
+            self.tracks_videos: Tuple[Tuple[int, Optional[Union[Track, Video]]]] = (
+                tuple(tracks_videos)
+            )
         return tracks_videos
 
     def flatten_playlist_dir(self):
@@ -554,9 +554,9 @@ def get_playlist(
         playlists_response: dict = request_playlist_items(
             session=session, playlist_id=playlist_id
         )
-        playlists_items_response_json: Optional[
-            "PlaylistsItemsResponseJSON"
-        ] = playlist_maker(playlists_response=playlists_response)
+        playlists_items_response_json: Optional["PlaylistsItemsResponseJSON"] = (
+            playlist_maker(playlists_response=playlists_response)
+        )
     except Exception as e:
         logger.exception(TidalPlaylistException(e.args[0]))
     finally:

--- a/tidal_wave/track.py
+++ b/tidal_wave/track.py
@@ -159,6 +159,10 @@ class Track:
         self.album_dir: Path = out_dir / artist_substring / album_substring
         self.album_dir.mkdir(parents=True, exist_ok=True)
 
+        # Create cover_path here, even if the API
+        # does not return a cover, to avoid AttributeError later
+        self.cover_path: Path = self.album_dir / "cover.jpg"
+
         if self.album.number_of_volumes > 1:
             volume_substring: str = f"Volume {self.metadata.volume_number}"
             (self.album_dir / volume_substring).mkdir(parents=True, exist_ok=True)
@@ -284,7 +288,6 @@ class Track:
     def save_album_cover(self, session: Session):
         """This method saves cover.jpg to self.album_dir; the bytes for cover.jpg
         come from self.album.cover"""
-        self.cover_path: Path = self.album_dir / "cover.jpg"
         if not self.cover_path.exists():
             download_cover_image(
                 session=session, cover_uuid=self.album.cover, output_dir=self.album_dir
@@ -588,9 +591,9 @@ class Track:
             for k, v in tags.copy().items():
                 if k.startswith("----"):
                     if isinstance(v, str):
-                        tags[k]: bytes = v.encode("UTF-8")
+                        tags[k] = v.encode("UTF-8")
                     elif isinstance(v, list):
-                        tags[k]: List[bytes] = [s.encode("UTF-8") for s in v]
+                        tags[k] = [s.encode("UTF-8") for s in v]
 
             tags["trkn"] = [(self.metadata.track_number, self.album.number_of_tracks)]
             tags["disk"] = [(self.metadata.volume_number, self.album.number_of_volumes)]

--- a/tidal_wave/video.py
+++ b/tidal_wave/video.py
@@ -51,10 +51,10 @@ class Video:
 
     def get_contributors(self, session: Session):
         """Request from TIDAL API /videos/contributors endpoint"""
-        self.contributors: Optional[
-            VideosContributorsResponseJSON
-        ] = request_video_contributors(
-            session=session, video_id=self.video_id, transparent=self.transparent
+        self.contributors: Optional[VideosContributorsResponseJSON] = (
+            request_video_contributors(
+                session=session, video_id=self.video_id, transparent=self.transparent
+            )
         )
 
     def get_stream(self, session: Session, video_format=VideoFormat.high):
@@ -289,9 +289,9 @@ class Video:
         for k, v in tags.copy().items():
             if k.startswith("----"):
                 if isinstance(v, str):
-                    tags[k]: bytes = v.encode("UTF-8")
+                    tags[k] = v.encode("UTF-8")
                 elif isinstance(v, list):
-                    tags[k]: List[bytes] = [s.encode("UTF-8") for s in v]
+                    tags[k] = [s.encode("UTF-8") for s in v]
 
         self.tags: dict = {k: v for k, v in tags.items() if v is not None}
 


### PR DESCRIPTION
For albums without an album cover, previously the retrieving of tracks would give up if there is no album_cover. This pull request changes this behavior so that a warning is logged, and the `self.cover_path` attribute is written in `self.set_album_dir()` in both track.py and album.py

* In track.py and album.py, move `self.cover_path` definition to `set_album_dir()`