### PR TITLE
For .mp4 and .m4a Files, Add FFmpeg flag `-movflags +faststart`

### DIFF
--- a/.github/workflows/pyinstaller-macos_arm64.yml
+++ b/.github/workflows/pyinstaller-macos_arm64.yml
@@ -35,6 +35,7 @@ jobs:
 
       - name: Update Homebrew
         id: update-homebrew
+        continue-on-error: true
         run: |
           brew update --preinstall
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 FROM docker.io/library/debian:bookworm-slim as build_image
 RUN export DEBIAN_FRONTEND=noninteractive && \
     apt-get update -qq && \
-    apt-get -y install --no-install-recommends g++ gcc git make pkg-config yasm && \
+    apt-get -y install --no-install-recommends ca-certificates g++ gcc git make pkg-config yasm && \
     git clone --single-branch --branch n6.1.1 --depth=1 https://github.com/FFmpeg/FFmpeg.git /opt/ffmpeg-n6.1.1
 
 WORKDIR /opt/ffmpeg-n6.1.1

--- a/tidal_wave/track.py
+++ b/tidal_wave/track.py
@@ -659,7 +659,7 @@ class Track:
 
         elif self.codec == "m4a":
             _cmd: str = f"""ffmpeg -hide_banner -loglevel quiet -y -i "{self.absolute_outfile}"
-                -map 0:a:0 -map 0:v:0 -map_metadata 0 -c:a copy -c:v copy "%s" """
+                -map 0:a:0 -map 0:v:0 -map_metadata 0 -c:a copy -c:v copy -movflags +faststart "%s" """
             if self.mutagen.get("covr") is not None:
                 if isinstance(self.mutagen["covr"], list):
                     if len(self.mutagen["covr"]) == 1:


### PR DESCRIPTION
This is a simple "optimization" for audio and video files in the MPEG4-type containers: for most use cases, it provides a speedup in terms of playing back the audio or video data. See [here](https://trac.ffmpeg.org/wiki/Encode/AAC#ProgressiveDownload)