### PR TITLE
Bump Dependence Version and Re-add User Prompt Option

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ dependencies = [
     "platformdirs==4.2.0",
     "pycryptodome==3.20.0",
     "requests[socks]==2.31.0",
-    "typer==0.12.1"
+    "typer==0.12.2"
 ]
 [project.scripts]
 tidal-wave = "tidal_wave.main:app"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ dependencies = [
     "platformdirs==4.2.0",
     "pycryptodome==3.20.0",
     "requests[socks]==2.31.0",
-    "typer==0.12.2"
+    "typer==0.12.3"
 ]
 [project.scripts]
 tidal-wave = "tidal_wave.main:app"

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,4 +7,4 @@ m3u8==4.1.0
 platformdirs==4.2.0
 pycryptodome==3.20.0
 requests[socks]==2.31.0
-typer==0.12.1
+typer==0.12.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,4 +7,4 @@ m3u8==4.1.0
 platformdirs==4.2.0
 pycryptodome==3.20.0
 requests[socks]==2.31.0
-typer==0.12.2
+typer==0.12.3

--- a/tidal_wave/login.py
+++ b/tidal_wave/login.py
@@ -301,7 +301,7 @@ def login(
         _input: str = ""
         while _input not in options:
             _input = typer.prompt(
-                "For which of Android [a] or Windows [w] would you like to provide an API token?"
+                "For which of Android [a], macOS [m], or Windows [w] would you like to provide an API token?"
             ).lower()
         else:
             if _input in {"android", "a"}:


### PR DESCRIPTION
When the option of passing a macOS-gleaned token was reintroduced to the codebase, I had forgotten to re-add the prompt option in `tidal_wave/login.py`. This pull request fixes that oversight.