### PR TITLE
More than 100 items

### DIFF
--- a/tidal_wave/mix.py
+++ b/tidal_wave/mix.py
@@ -35,7 +35,7 @@ class Mix:
 
     def set_metadata(self, session: Session):
         """Request from TIDAL API /mixes endpoint"""
-        self.metadata: Optional[SimpleNamespace] = request_mixes(
+        self.metadata: Optional[SimpleNamespace] = request_mix(
             session=session, mix_id=self.mix_id
         )
 
@@ -47,13 +47,18 @@ class Mix:
     def set_items(self, session: Session):
         """Uses data from TIDAL API /mixes/items endpoint to
         populate self.items"""
-        mix_items: Optional[MixesItemsResponseJSON] = get_mix(
-            session=session, mix_id=self.mix_id
-        )
-        if mix_items is None:
+        try:
+            mix_items: Optional[MixesItemsResponseJSON] = retrieve_mix_items(
+                session=session, mix_id=self.mix_id
+            )
+        except TidalMixException as tme:
+            logger.exception(tme.args[0])
             self.items = tuple()
         else:
-            self.items: Tuple[Optional[MixItem]] = tuple(filter(None, mix_items.items))
+            if mix_items is None:
+                self.items = tuple()
+            else:
+                self.items: Tuple[Optional[MixItem]] = tuple(filter(None, mix_items.items))
 
     def set_mix_dir(self, out_dir: Path):
         """Populates self.mix_dir based on self.name, self.mix_id"""
@@ -66,6 +71,7 @@ class Mix:
         if self.mix_dir is None:
             self.set_mix_dir(out_dir=out_dir)
         self.cover_path: Path = self.mix_dir / "cover.jpg"
+
         if not self.cover_path.exists():
             with session.get(
                 url=self.metadata.image, params={k: None for k in session.params}
@@ -74,18 +80,19 @@ class Mix:
 
             self.mix_cover_saved = True
         else:
-            self.mix_cover_saved = True
+            if self.cover_path.stat().st_size > 0:
+                self.mix_cover_saved = True
 
     def get_items(
         self, session: Session, audio_format: AudioFormat, no_extra_files: bool
-    ):
+    ) -> Tuple[Optional[Union[Track, Video]]]:
         """Using either Track.get() or Video.get(), attempt to request
         the data for each track or video in self.items."""
         if len(self.items) == 0:
             self.files = {}
             return
 
-        tracks_videos: list = [None] * len(self.items)
+        tracks_videos: List[Optional[Union[Track, Video]]] = [None] * len(self.items)
         for i, item in enumerate(self.items):
             if item is None:
                 tracks_videos[i] = None
@@ -112,7 +119,7 @@ class Mix:
                 tracks_videos[i] = None
                 continue
         else:
-            self.tracks_videos: Tuple[Tuple[int, Optional[Union[Track, Video]]]] = (
+            self.tracks_videos: Tuple[Optional[Union[Track, Video]]] = (
                 tuple(tracks_videos)
             )
         return tracks_videos
@@ -127,8 +134,8 @@ class Mix:
         files: List[Dict[int, Optional[str]]] = [None] * len(self.tracks_videos)
         if len(self.tracks_videos) == 0:
             return
-        subdirs: Set[Path] = set()
 
+        subdirs: Set[Path] = set()
         for i, tv in enumerate(self.tracks_videos, 1):
             if getattr(tv, "outfile") is None:
                 try:
@@ -318,7 +325,7 @@ class TidalMixException(Exception):
     pass
 
 
-def request_mixes(session: Session, mix_id: str) -> Optional[SimpleNamespace]:
+def request_mix(session: Session, mix_id: str) -> Optional[SimpleNamespace]:
     """Request from TIDAL API /pages/mix endpoint. If an error occurs from
     session.get(), None is returned. Otherwise, a typing.SimpleNamespace
     object is returned with some metadata to do with the mix: title,
@@ -327,7 +334,7 @@ def request_mixes(session: Session, mix_id: str) -> Optional[SimpleNamespace]:
     kwargs: dict = {"url": url}
     kwargs["headers"] = {"Accept": "application/json"}
 
-    logger.info(f"Requesting from TIDAL API: mixes/{mix_id}/items")
+    logger.info(f"Requesting from TIDAL API: mixes/{mix_id}")
     with session.get(**kwargs) as resp:
         try:
             resp.raise_for_status()
@@ -340,9 +347,11 @@ def request_mixes(session: Session, mix_id: str) -> Optional[SimpleNamespace]:
                 logger.exception(he)
             return
 
-        d = dict()
-        d["title"] = resp.json().get("title")
-        d["description"] = resp.json().get("rows")[0]["modules"][0]["mix"]["subTitle"]
+        # TODO: add logic for 'transparent' flag
+        d: Dict[str, str] = {
+            "title": resp.json().get("title"),
+            "description": resp.json().get("rows")[0]["modules"][0]["mix"]["subTitle"],
+        }
         d["image"] = (
             resp.json()
             .get("rows", [{}])[0]
@@ -355,15 +364,18 @@ def request_mixes(session: Session, mix_id: str) -> Optional[SimpleNamespace]:
         return SimpleNamespace(**d)
 
 
-def request_mix_items(session: Session, mix_id: str) -> Optional[Dict]:
+def request_mixes_items(
+    session: Session, mix_id: str, offset: Optional[int] = None
+) -> Optional[Dict]:
     """Request from TIDAL API /mixes/items endpoint. If error arises when
     requesting with 'session'.get(), None is returned. Otherwise, the
     dict object returned by requests.Response.json() is returned."""
     url: str = f"{TIDAL_API_URL}/mixes/{mix_id}/items"
     kwargs: dict = {"url": url}
-    kwargs["params"] = {"limit": 100}
+    kwargs["params"] = {"limit": 100} if offset is None else {"limit": 100, "offset": offset}
     kwargs["headers"] = {"Accept": "application/json"}
 
+    # TODO: add logic for 'transparent' flag
     data: Optional[dict] = None
     logger.info(f"Requesting from TIDAL API: mixes/{mix_id}/items")
     with session.get(**kwargs) as resp:
@@ -398,7 +410,7 @@ class MixesItemsResponseJSON:
     ]
 
 
-def mix_maker(
+def mix_items_response_json_maker(
     mixes_response: Dict[str, Union[int, List[dict]]],
 ) -> "MixesItemsResponseJSON":
     """This function massages the response from the TIDAL API endpoint
@@ -452,15 +464,65 @@ def mix_maker(
     return MixesItemsResponseJSON(**init_args)
 
 
-def get_mix(session: Session, mix_id: str) -> Optional["MixesItemsResponseJSON"]:
+def retrieve_mix_items(session: Session, mix_id: str) -> Optional["MixesItemsResponseJSON"]:
     """The pattern for mix items retrieval does not follow the
-    requesting.request_* functions, hence its implementation here.
+    requesting.request_* functions, hence its implementation here. N.b.
+    if the first response from /mixes/<ID>/items endpoint indicates that
+    the playlist contains more than 100 items, multiple requests will be
+    sent until all N > 100 items are retrieved.
     """
     mixes_items_response_json: Optional["MixesItemsResponseJSON"] = None
+    mixes_response: Optional[dict] = request_mixes_items(
+        session=session, mix_id=mix_id
+    )
+    if mixes_response is None:
+        raise TidalMixException(f"Could not retrieve the items in mix '{mix_id}'")
+
+    total_number_of_items: Optional[int] = mixes_response.get("totalNumberOfItems")
+    if total_number_of_items is None:
+        raise TidalMixException(
+            f"TIDAL API did not respond with number of items in mix '{mix_id}'"
+        )
+    else:
+        logger.info(f"Mix '{mix_id}' is comprised of {total_number_of_items} items")
+    
+    num_items: int = len(mixes_response.get("items", []))
+    if num_items == 0:
+        raise TidalMixException(
+            f"TIDAL API did not return any mix items for mix '{mix_id}'"
+        )
+
+    if num_items < total_number_of_items:
+        items_to_retrieve: int = total_number_of_items
+        all_items_mixes_response: dict = mixes_response
+        if total_number_of_items > 100:
+            items_list: List[dict] = mixes_response.pop("items")
+            offset: int = 100
+            while items_to_retrieve > 0:
+                mr: Optional[dict] = request_mixes_items(
+                    session=session, mix_id=mix_id, offset=offset
+                )
+                if (mr is not None) and ((mr_items := mr.get("items")) is not None):
+                    items_list += mr_items
+                    offset += 100
+                    items_to_retrieve -= 100
+                else:
+                    logger.exception(
+                        TidalPlaylistException(
+                            f"Could not retrieve more than {len(items_list)} "
+                            f"elements of mix '{mix_id}'. Continuing "
+                            "without the remaining "
+                            f"{total_number_of_items - len(items_list)}"
+                        )
+                    )
+        else:
+            all_items_mixes_response = mixes_response
+    else:
+        all_items_mixes_response = mixes_response
+
     try:
-        mixes_response: dict = request_mix_items(session=session, mix_id=mix_id)
-        mixes_items_response_json: Optional["MixesItemsResponseJSON"] = mix_maker(
-            mixes_response=mixes_response
+        mixes_items_response_json: Optional["MixesItemsResponseJSON"] = mix_items_response_json_maker(
+            mixes_response=all_items_mixes_response
         )
     except Exception as e:
         logger.exception(TidalMixException(e.args[0]))

--- a/tidal_wave/mix.py
+++ b/tidal_wave/mix.py
@@ -528,7 +528,7 @@ def retrieve_mix_items(
                     items_to_retrieve -= 100
                 else:
                     logger.exception(
-                        TidalPlaylistException(
+                        TidalMixException(
                             f"Could not retrieve more than {len(items_list)} "
                             f"elements of mix '{mix_id}'. Continuing "
                             "without the remaining "

--- a/tidal_wave/models.py
+++ b/tidal_wave/models.py
@@ -260,7 +260,7 @@ class SubscriptionEndpointResponseJSON(dataclass_wizard.JSONWizard):
 class AlbumsItemsResponseJSONItem:
     """A sub-object of the response from the TIDAL API endpoint
     /albums/<ID>/items. It simply denotes the type of item, which is surely
-    going to be 'track', and the same object that is returned from the TIDAL
+    going to be 'track', and is the same object that is returned from the TIDAL
     API /tracks endpoint."""
 
     item: "TracksEndpointResponseJSON"

--- a/tidal_wave/playlist.py
+++ b/tidal_wave/playlist.py
@@ -62,15 +62,10 @@ class Playlist:
         )
         if playlist_items is None:
             self.items = tuple()
-
-        # For now, if playlist size, N, exceeds 100 items,
-        # N items are returned, and all those between 101 and N
-        # are simply None. It's a temporary fix before properly
-        # handling paginated API requests, but it should stop
-        # NoneType errors!
-        self.items: Tuple[Optional[PlaylistItem]] = tuple(
-            filter(None, playlist_items.items)
-        )
+        else:
+            self.items: Tuple[Optional[PlaylistItem]] = tuple(
+                filter(None, playlist_items.items)
+            )
 
     def set_playlist_dir(self, out_dir: Path):
         """Populates self.playlist_dir based on self.name, self.playlist_id"""
@@ -136,7 +131,7 @@ class Playlist:
                 tracks_videos[i] = None
                 continue
         else:
-            self.tracks_videos: Tuple[Tuple[int, Optional[Union[Track, Video]]]] = (
+            self.tracks_videos: Tuple[Optional[Union[Track, Video]]] = (
                 tuple(tracks_videos)
             )
         return tracks_videos
@@ -195,7 +190,6 @@ class Playlist:
             self.files: List[Dict[int, Optional[str]]] = files
 
         # Find all subdirectories written to
-        subdirs: Set[Path] = set()
         for tv in self.tracks_videos:
             if isinstance(tv, Track):
                 try:

--- a/tidal_wave/playlist.py
+++ b/tidal_wave/playlist.py
@@ -53,21 +53,23 @@ class Playlist:
 
     def set_items(self, session: Session):
         """Uses data from TIDAL API /playlists/items endpoint to
-        populate self.items"""
-        playlist_items: Optional[PlaylistsItemsResponseJSON] = get_playlist(
+        populate self.items.  If 'totalNumberOfItems' field returned
+        has value greater than 100, multiple requests of size <= 100 will be
+        sent to the endpoint until all items for the playlist are retrieved."""
+        playlist_items: Optional[PlaylistsItemsResponseJSON] = retrieve_playlist_items(
             session=session, playlist_id=self.playlist_id
         )
         if playlist_items is None:
             self.items = tuple()
-        else:
-            # For now, if playlist size, N, exceeds 100 items,
-            # N items are returned, and all those between 101 and N
-            # are simply None. It's a temporary fix before properly
-            # handling paginated API requests, but it should stop
-            # NoneType errors!
-            self.items: Tuple[Optional[PlaylistItem]] = tuple(
-                filter(None, playlist_items.items)
-            )
+
+        # For now, if playlist size, N, exceeds 100 items,
+        # N items are returned, and all those between 101 and N
+        # are simply None. It's a temporary fix before properly
+        # handling paginated API requests, but it should stop
+        # NoneType errors!
+        self.items: Tuple[Optional[PlaylistItem]] = tuple(
+            filter(None, playlist_items.items)
+        )
 
     def set_playlist_dir(self, out_dir: Path):
         """Populates self.playlist_dir based on self.name, self.playlist_id"""
@@ -445,14 +447,16 @@ class TidalPlaylistException(Exception):
     pass
 
 
-def request_playlist_items(session: Session, playlist_id: str) -> Optional[dict]:
+def request_playlists_items(
+    session: Session, playlist_id: str, offset: Optional[int] = None
+) -> Optional[dict]:
     """Request from TIDAL API /playlists/items endpoint. If requests.HTTPError
     arises, warning is logged; upon this or any other exception, None is returned.
     If no exception arises from 'session'.get(), the requests.Response.json()
     object is returned."""
     url: str = f"{TIDAL_API_URL}/playlists/{playlist_id}/items"
     kwargs: dict = {"url": url}
-    kwargs["params"] = {"limit": 100}
+    kwargs["params"] = {"limit": 100} if offset is None else {"limit": 100, "offset": offset}
     kwargs["headers"] = {"Accept": "application/json"}
 
     data: Optional[dict] = None
@@ -489,16 +493,17 @@ class PlaylistsItemsResponseJSON:
     ]
 
 
-def playlist_maker(
+def playlists_items_response_json_maker(
     playlists_response: Dict[str, Union[int, List[dict]]],
 ) -> "PlaylistsItemsResponseJSON":
     """This function massages the response from the TIDAL API endpoint
-    playlists/items into a format that PlaylistsItemsResponseJSON.from_dict()
-    can ingest. Returns a PlaylistsItemsResponseJSON instance"""
-    init_args: dict = {}
-    init_args["limit"] = playlists_response.get("limit")
-    init_args["offset"] = playlists_response.get("offset")
-    init_args["total_number_of_items"] = playlists_response.get("totalNumberOfItems")
+    /playlists/items into a format that PlaylistsItemsResponseJSON.__init__()
+    can ingest, and then returns a PlaylistsItemsResponseJSON instance"""
+    init_args: Dict[str, Optional[int]] = {
+        "limit": playlists_response.get("limit"),
+        "offset": playlists_response.get("offset"),
+        "total_number_of_items": playlists_response.get("totalNumberOfItems")
+    }
 
     items: Tuple[SimpleNamespace] = tuple(
         SimpleNamespace(**d) for d in playlists_response["items"]
@@ -543,19 +548,64 @@ def playlist_maker(
     return PlaylistsItemsResponseJSON(**init_args)
 
 
-def get_playlist(
+def retrieve_playlist_items(
     session: Session, playlist_id: str
 ) -> Optional["PlaylistsItemsResponseJSON"]:
     """The pattern for playlist items retrieval does not follow the
-    requesting.request_* functions, hence its implementation here.
-    """
+    requesting.request_* functions, hence its implementation here. N.b.
+    if the first response from /playlists/items endpoint indicates that
+    the playlist contains more than 100 items, multiple requests will be
+    sent until all N > 100 items are retrieved."""
     playlists_items_response_json: Optional["PlaylistsItemsResponseJSON"] = None
-    try:
-        playlists_response: dict = request_playlist_items(
-            session=session, playlist_id=playlist_id
+    playlists_response: Optional[dict] = request_playlists_items(
+        session=session, playlist_id=playlist_id
+    )
+    if playlists_response is None:
+        raise TidalPlaylistException(
+            f"Could not retrieve the items in playlist '{playlist_id}'"
         )
+
+    total_number_of_items: Optional[int] = playlists_response.get("totalNumberOfItems")
+    logger.info(f"Playlist '{playlist_id}' is comprised of {total_number_of_items} items")
+    if total_number_of_items is None:
+        raise TidalPlaylistException(
+            f"TIDAL API did not respond with number of items in playlist '{playlist_id}'"
+        )
+    else:
+        items_to_retrieve: int = total_number_of_items
+    
+    all_items_playlist_response: dict = playlists_response
+
+    # TODO: some more clever, perhaps recursive solution is warranted here
+    if total_number_of_items > 100:
+        items_list: List[dict] = playlists_response.pop("items")
+        offset: int = 100
+        while items_to_retrieve > 0:
+            pr: Optional[dict] = request_playlists_items(
+                session=session, playlist_id=playlist_id, offset=offset
+            )
+            # TODO: some better error checking here. Depending on the
+            # robustness of the TIDAL API...
+            if (pr is not None) and ((pr_items := pr.get("items")) is not None):
+                items_list += pr_items
+                offset += 100
+                items_to_retrieve -= 100
+            else:
+                logger.exception(
+                    TidalPlaylistException(
+                        f"Could not retrieve more than {len(items_list)} "
+                        f"elements of playlist '{playlist_id}'. Continuing "
+                        "without the remaining "
+                        f"{total_number_of_items - len(items_list)}"
+                    )
+                )
+        else:
+            all_items_playlist_response["items"] = items_list
+            
+
+    try:
         playlists_items_response_json: Optional["PlaylistsItemsResponseJSON"] = (
-            playlist_maker(playlists_response=playlists_response)
+            playlists_items_response_json_maker(playlists_response=all_items_playlist_response)
         )
     except Exception as e:
         logger.exception(TidalPlaylistException(e.args[0]))

--- a/tidal_wave/requesting.py
+++ b/tidal_wave/requesting.py
@@ -64,17 +64,22 @@ def requester_maker(
     subclass: Optional["ResponseJSON"] = None,
     credits_flag: bool = False,
     transparent: bool = False,
+    offset: Optional[int] = None,
 ) -> Callable:
     """This function is a function factory: it crafts nearly identical
     versions of the same logic: send a GET request to a certain endpoint;
     if a requests.HTTPError arises, return None; else, transform the
     JSON response into an instance of a subclass of JSONWizard."""
 
-    def function(s, e, i, u, h, p, sc, cf, t):
+    def function(s, e, i, u, h, p, sc, cf, t, o):
         url: str = f"{TIDAL_API_URL}/{e}/{i}{u}"
         kwargs: dict = {"url": url}
         if p is not None:
-            kwargs["params"] = p
+            kwargs["params"] = p if offset is None else p | {"offset": offset}
+        else:
+            if offset is not None:
+                kwargs["params"] = {"offset": offset}
+
         if h is not None:
             kwargs["headers"] = h
 
@@ -86,7 +91,7 @@ def requester_maker(
             logger=logger,
         )
         def _get(s: Session, request_kwargs: dict) -> Response:
-            """Return a requests.Response object, from having passed request_kwargs
+            """Return a requests.Response object from having passed request_kwargs
             to s.get(), optionally retrying if 429 error occurs."""
             with s.get(**request_kwargs) as r:
                 return r
@@ -135,6 +140,7 @@ def requester_maker(
         sc=subclass,
         cf=credits_flag,
         t=transparent,
+        o=offset,
     )
 
 
@@ -142,11 +148,12 @@ def requester_maker(
 # don't change during runtime, and session is only available once the __main__
 # process (on the happy path) creates a requests.Session object. Identifier
 # varies with the media type, etc.
-
-
 def request_albums(
     session: Session, album_id: int, transparent: bool = False
 ) -> Optional[AlbumsEndpointResponseJSON]:
+    """Send a GET request to the /albums endpoint of the TIDAL API. If an
+    Exception occurs, return None. Else, return an instance of
+    AlbumsEndpointResponseJSON"""
     return requester_maker(
         session=session,
         endpoint="albums",
@@ -157,9 +164,16 @@ def request_albums(
     )
 
 
-def request_album_items(
-    session: Session, album_id: int, transparent: bool = False
+def request_albums_items(
+    session: Session,
+    album_id: int,
+    transparent: bool = False,
+    offset: Optional[int] = None,
 ) -> Optional[AlbumsItemsResponseJSON]:
+    """Send a GET request to the /albums/<album ID>/items
+    endpoint of the TIDAL API. If an Exception occurs,
+    return None. Else, return an instance of
+    AlbumsItemsResponseJSON"""
     return requester_maker(
         session=session,
         endpoint="albums",
@@ -169,12 +183,16 @@ def request_album_items(
         url_end="/items",
         subclass=AlbumsItemsResponseJSON,
         transparent=transparent,
+        offset=offset,
     )
 
 
 def request_album_review(
     session: Session, album_id: int, transparent: bool = False
 ) -> Optional[AlbumsReviewResponseJSON]:
+    """Send a GET request to the /albums/<album ID>/review
+    endpoint of the TIDAL API. If an Exception occurs, return None.
+    Else, return an instance of AlbumsReviewResponseJSON"""
     return requester_maker(
         session=session,
         endpoint="albums",
@@ -189,6 +207,9 @@ def request_album_review(
 def request_artist_bio(
     session: Session, artist_id: int, transparent: bool = False
 ) -> Optional[ArtistsBioResponseJSON]:
+    """Send a GET request to the /artists/<artist ID>/bio
+    endpoint of the TIDAL API. If an Exception occurs, return None.
+    Else, return an instance of ArtistsBioResponseJSON"""
     return requester_maker(
         session=session,
         endpoint="artists",
@@ -203,6 +224,9 @@ def request_artist_bio(
 def request_artists(
     session: Session, artist_id: int, transparent: bool = False
 ) -> Optional[ArtistsEndpointResponseJSON]:
+    """Send a GET request to the /artists endpoint of the TIDAL API.
+    If an Exception occurs, return None. Else, return an instance of
+    ArtistsEndpointResponseJSON"""
     return requester_maker(
         session=session,
         endpoint="artists",
@@ -216,6 +240,9 @@ def request_artists(
 def request_artists_albums(
     session: Session, artist_id: int, transparent: bool = False
 ) -> Optional[ArtistsAlbumsResponseJSON]:
+    """Send a GET request to the /artists/<artist ID>/albums
+    endpoint of the TIDAL API. If an Exception occurs, return None.
+    Else, return an instance of ArtistsAlbumsResponseJSON"""
     return requester_maker(
         session=session,
         endpoint="artists",
@@ -230,6 +257,9 @@ def request_artists_albums(
 def request_artists_audio_works(
     session: Session, artist_id: int, transparent: bool = False
 ) -> Optional[ArtistsAlbumsResponseJSON]:
+    """Send a GET request to the /artists/<artist ID>/albums
+    endpoint of the TIDAL API. If an Exception occurs, return None.
+    Else, return an instance of ArtistsAlbumsResponseJSON"""
     return requester_maker(
         session=session,
         endpoint="artists",
@@ -245,6 +275,9 @@ def request_artists_audio_works(
 def request_artists_videos(
     session: Session, artist_id: int, transparent: bool = False
 ) -> Optional[ArtistsVideosResponseJSON]:
+    """Send a GET request to the /artists/<artist ID>/videos
+    endpoint of the TIDAL API. If an Exception occurs, return None.
+    Else, return an instance of ArtistsVideosResponseJSON"""
     return requester_maker(
         session=session,
         endpoint="artists",
@@ -259,6 +292,9 @@ def request_artists_videos(
 def request_tracks(
     session: Session, track_id: int, transparent: bool = False
 ) -> Optional[TracksEndpointResponseJSON]:
+    """Send a GET request to the /tracks endpoint of the TIDAL API.
+    If an Exception occurs, return None. Else, return an instance of
+    TracksEndpointResponseJSON"""
     return requester_maker(
         session=session,
         endpoint="tracks",
@@ -275,6 +311,9 @@ def request_tracks(
 def request_credits(
     session: Session, track_id: int, transparent: bool = False
 ) -> Optional[TracksCreditsResponseJSON]:
+    """Send a GET request to the /tracks/<track ID>/credits endpoint of the
+    TIDAL API. If an Exception occurs, return None. Else, return an instance
+    of TracksCreditsResponseJSON"""
     return requester_maker(
         session=session,
         endpoint="tracks",
@@ -294,6 +333,9 @@ def request_credits(
 def request_albums_credits(
     session: Session, album_id: int, transparent: bool = False
 ) -> Optional[AlbumsCreditsResponseJSON]:
+    """Send a GET request to the /albums/<album ID>/credits endpoint of the
+    TIDAL API. If an Exception occurs, return None. Else, return an instance
+    of AlbumsCreditsResponseJSON"""
     return requester_maker(
         session=session,
         endpoint="albums",
@@ -310,6 +352,9 @@ def request_albums_credits(
 def request_lyrics(
     session: Session, track_id: int, transparent: bool = False
 ) -> Optional[TracksLyricsResponseJSON]:
+    """Send a GET request to the /tracks/<track ID>/lyrics endpoint of the
+    TIDAL API. If an Exception occurs, return None. Else, return an instance
+    of TracksLyricsResponseJSON"""
     return requester_maker(
         session=session,
         endpoint="tracks",
@@ -326,6 +371,9 @@ def request_lyrics(
 def request_stream(
     session: Session, track_id: int, audio_quality: str, transparent: bool = False
 ) -> Optional[TracksEndpointStreamResponseJSON]:
+    """Send a GET request to the /tracks/<track ID>/playbackinfopostpaywall
+    endpoint of the TIDAL API. If an Exception occurs, return None. Else,
+    return an instance of TracksEndpointStreamResponseJSON"""
     func = partial(
         requester_maker,
         session=session,
@@ -347,6 +395,9 @@ def request_stream(
 def request_videos(
     session: Session, video_id: int, transparent: bool = False
 ) -> Optional[VideosEndpointResponseJSON]:
+    """Send a GET request to the /videos endpoint of the TIDAL API.
+    If an Exception occurs, return None. Else, return an instance of
+    VideosEndpointResponseJSON"""
     return requester_maker(
         session=session,
         endpoint="videos",
@@ -360,6 +411,9 @@ def request_videos(
 def request_video_contributors(
     session: Session, video_id: int, transparent: bool = False
 ) -> Optional[VideosContributorsResponseJSON]:
+    """Send a GET request to the /videos/<video ID>/contributors endpoint of the
+    TIDAL API. If an Exception occurs, return None. Else, return an instance
+    of VideosContributorsResponseJSON"""
     return requester_maker(
         session=session,
         endpoint="videos",
@@ -375,6 +429,9 @@ def request_video_contributors(
 def request_video_stream(
     session: Session, video_id: int, video_quality: str, transparent: bool = False
 ) -> Optional[VideosEndpointStreamResponseJSON]:
+    """Send a GET request to the /videos/<video ID>/playbackinfopostpaywall
+    endpoint of the TIDAL API. If an Exception occurs, return None. Else,
+    return an instance of VideosEndpointStreamResponseJSON"""
     func = partial(
         requester_maker,
         session=session,
@@ -396,6 +453,9 @@ def request_video_stream(
 def request_playlists(
     session: Session, playlist_id: int, transparent: bool = False
 ) -> Optional[PlaylistsEndpointResponseJSON]:
+    """Send a GET request to the /playlists endpoint of the TIDAL API.
+    If an Exception occurs, return None. Else, return an instance of
+    PlaylistsEndpointResponseJSON"""
     return requester_maker(
         session=session,
         endpoint="playlists",


### PR DESCRIPTION
This pull request addresses #155, which has been a topic I have been avoiding for some time.

- `tidal_wave/playlist.py`: change the name of functions, add some documentation, but mostly add the `transparent` flag logic as well as retrieving all $N$ playlist elements, $N>100$
- `tidal_wave/mix.py`: Add the logic for `transparent` flag as well as retrieving all $N$ mix elements, $N>100$
- `tidal_wave/requesting.py`: Add docstrings to all `request_*` functions as well as add `offset` parameter to `requesting.requester_maker()` and `requesting.request_albums_items()`
- in `tidal_wave/album.py`: Extend `album.Album.set_tracks()` to retrieve all $N$ tracks in an album, $N>100$