### PR TITLE
Workaround for forward slash in artist name

### DIFF
--- a/tidal_wave/album.py
+++ b/tidal_wave/album.py
@@ -112,7 +112,7 @@ class Album:
         """This method populates self.album_dir as a sub-subdirectory of
         out_dir: its parent directory is the name of the (main) artist of
         the album"""
-        artist_substring: str = self.metadata.artist.name.replace("..", "")
+        artist_substring: str = self.metadata.artist.name.replace("..", "").replace("/", "and")
         album_substring: str = (
             f"{self.metadata.name.replace('..', '')} "
             f"[{self.metadata.id}] [{self.metadata.release_date.year}]"

--- a/tidal_wave/artist.py
+++ b/tidal_wave/artist.py
@@ -70,7 +70,7 @@ class Artist:
     def set_artist_dir(self, out_dir: Path):
         """This method sets self.artist_dir and creates the directory on the file system
         if it does not exist"""
-        self.name: str = self.metadata.name.replace("..", "")
+        self.name: str = self.metadata.name.replace("..", "").replace("/", "and")
         self.artist_dir = out_dir / self.name
         self.artist_dir.mkdir(parents=True, exist_ok=True)
 

--- a/tidal_wave/track.py
+++ b/tidal_wave/track.py
@@ -152,7 +152,7 @@ class Track:
         """This method sets self.album_dir, based on self.album and
         out_dir. In particular, self.album_dir is a subdirectory of out_dir
         based on the name of the album's artist"""
-        artist_substring: str = self.album.artist.name.replace("..", "")
+        artist_substring: str = self.album.artist.name.replace("..", "").replace("/", "and")
         album_substring: str = (
             f"{self.album.name} " f"[{self.album.id}] [{self.album.release_date.year}]"
         )
@@ -264,7 +264,7 @@ class Track:
         self.metadata.artists to self.album_dir"""
         for a in self.metadata.artists:
             track_artist_image: Path = (
-                self.album_dir / f"{a.name.replace('..', '')}.jpg"
+                self.album_dir / f"{a.name.replace('..', '').replace('/', 'and')}.jpg"
             )
             if not track_artist_image.exists():
                 download_artist_image(session, a, self.album_dir, dimension=750)

--- a/tidal_wave/video.py
+++ b/tidal_wave/video.py
@@ -93,7 +93,7 @@ class Video:
     def set_artist_dir(self, out_dir: Path):
         """Set self.artist_dir, which is the subdirectory of `out_dir`
         with name `self.metadata.artist.name`"""
-        self.artist_dir: Path = out_dir / self.metadata.artist.name
+        self.artist_dir: Path = out_dir / self.metadata.artist.name.replace("..", "").replace("/", "and")
         self.artist_dir.mkdir(parents=True, exist_ok=True)
 
     def set_filename(self, out_dir: Path):


### PR DESCRIPTION
Raised in issue #186, there are some artists per the TIDAL API that have (multiple) forward slash characters ( / ) in their names. This pull request implements the fix for this; substituting the slash for the word "and".