### PR TITLE
Hotfix for dependabot failures

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -22,29 +22,29 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3  # v6.0
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392  # v3.6.0
+        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130  # v3.7.0
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435  # v3.11.1
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f  # v3.12.0
 
       - name: Log in to the Container registry
-        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9  # v3.7.0
         with:
+          password: ${{ secrets.GITHUB_TOKEN }}
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Extract metadata (tags, labels) for Docker
         id: meta
-        uses: docker/metadata-action@902fa8ec7d6ecbf8d84d538b9b233a880e428804
+        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051  # v5.10.0
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8  # v6.19.2
         with:
           context: .
           push: true

--- a/.github/workflows/pyinstaller-macos_arm64.yml
+++ b/.github/workflows/pyinstaller-macos_arm64.yml
@@ -5,6 +5,8 @@ on:
     types: ["published"]
   push:
     branches: ["develop", "trunk"]
+  workflow_dispatch:
+
 permissions:
   contents: write
 jobs:
@@ -12,48 +14,56 @@ jobs:
     runs-on: macos-14
     steps:
       - name: Checkout repository
-        uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3  # v6.0
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
       - name: Set up Homebrew
         id: set-up-homebrew
         uses: Homebrew/actions/setup-homebrew@master
+
       - name: Cache Homebrew Bundler RubyGems
         id: cache
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830  # v4.3.0
+        uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306  # v5.0.3
         with:
           path: ${{ steps.set-up-homebrew.outputs.gems-path }}
           key: ${{ runner.os }}-rubygems-${{ steps.set-up-homebrew.outputs.gems-hash }}
           restore-keys: ${{ runner.os }}-rubygems-
+
       - name: Install Homebrew Bundler RubyGems
         if: steps.cache.outputs.cache-hit != 'true'
         run: brew install-bundler-gems
+
       - name: Update Homebrew
         id: update-homebrew
         continue-on-error: true
         run: |
           brew update
+
       # https://trac.ffmpeg.org/wiki/CompilationGuide/macOS#InstallingdependencieswithHomebrew
       - name: Get FFmpeg dependencies from Homebrew
         id: brew-install-ffmpeg-deps
         run: brew install automake nasm shtool xvid
+
       - name: Clone FFmpeg, n7.0 tag
         id: clone-ffmpeg-from-github
-        uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3  # v6.0
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: FFmpeg/FFmpeg
           path: ffmpeg-n7.0
           ref: n7.0
           fetch-depth: 1
+
       - name: Cache compiled ffmpeg
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830  # v4.3.0
+        uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306  # v5.0.3
         id: cache-ffmpeg-darwin-arm64
         with:
           path: ffmpeg-n7.0/ffmpeg
           key: macos-arm64-compiled-ffmpeg-n7.0
+
       - name: Build FFmpeg from source
         if: steps.cache-ffmpeg-darwin-arm64.outputs.cache-hit != 'true'
         id: compile-ffmpeg
+        working-directory: ./ffmpeg-n7.0
         run: |
-          cd ffmpeg-n7.0
           ./configure \
             --arch=arm64 \
             --target-os=darwin \
@@ -83,46 +93,61 @@ jobs:
             --enable-protocol=file \
             --enable-small
           make -j"$(sysctl -n hw.logicalcpu)"
+
       - name: Set up Python
-        uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c  # v6.0
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
         with:
-          cache: "pip"
+          architecture: "arm64"
           check-latest: false
-          python-version: "3.12.10"
+          python-version: "3.14.0"
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
+          python-version: '3.14.0'
+
       - name: Install dependencies
+        env:
+          UV_NO_MANAGED_PYTHON: 1
         run: |
-          python3 -m pip install --upgrade pip setuptools wheel
-          python3 -m pip install . --group build
-          python3 -m pip install pyinstaller==6.7.0
+          uv sync --locked --group build --no-group dev
+
       - name: Create Executable with Pyinstaller
+        env:
+          UV_NO_MANAGED_PYTHON: 1
         run: |
-          pyinstaller \
+          uv run --no-project pyinstaller \
             --name=tidal-wave_macos_aarch64 \
             --target-arch=arm64 \
             --paths src/tidal_wave \
             --exclude-module pyinstaller \
             --exclude-module ruff \
             --add-binary "ffmpeg-n7.0/ffmpeg:ffmpeg" \
+            --collect-all tzdata \
             --clean \
             --noupx \
             --onefile \
             --strip \
             ./pyinstaller.py
+
       - name: Test just-compiled binary
         run: |
           ./dist/tidal-wave_macos_aarch64 --help
+
       - name: Upload Artifact
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f  # v6.0.0
         if: startsWith(github.ref, 'refs/tags/')
         with:
-          compression-level: 9
+          compression-level: 0
           name: tidal-wave_macos_aarch64
           overwrite: true
           path: |
             ./dist/tidal-wave_macos_aarch64
           retention-days: 7
+
       - name: Add artifact to release
-        uses: softprops/action-gh-release@6da8fa9354ddfdc4aeace5fc48d7f679b5214090  # v2.4.1
+        uses: softprops/action-gh-release@a06a81a03ee405af7f2048a818ed3f03bbf83c7b  # v2.5.0
         if: startsWith(github.ref, 'refs/tags/')
         with:
           fail_on_unmatched_files: true

--- a/.github/workflows/pyinstaller-macos_arm64.yml
+++ b/.github/workflows/pyinstaller-macos_arm64.yml
@@ -16,27 +16,8 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - name: Set up Homebrew
-        id: set-up-homebrew
-        uses: Homebrew/actions/setup-homebrew@master
-
-      - name: Cache Homebrew Bundler RubyGems
-        id: cache
-        uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306  # v5.0.3
-        with:
-          path: ${{ steps.set-up-homebrew.outputs.gems-path }}
-          key: ${{ runner.os }}-rubygems-${{ steps.set-up-homebrew.outputs.gems-hash }}
-          restore-keys: ${{ runner.os }}-rubygems-
-
       - name: Install Homebrew Bundler RubyGems
-        if: steps.cache.outputs.cache-hit != 'true'
         run: brew install-bundler-gems
-
-      - name: Update Homebrew
-        id: update-homebrew
-        continue-on-error: true
-        run: |
-          brew update
 
       # https://trac.ffmpeg.org/wiki/CompilationGuide/macOS#InstallingdependencieswithHomebrew
       - name: Get FFmpeg dependencies from Homebrew
@@ -99,13 +80,13 @@ jobs:
         with:
           architecture: "arm64"
           check-latest: false
-          python-version: "3.14.0"
+          python-version: "3.14.3"
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@eac588ad8def6316056a12d4907a9d4d84ff7a3b  # v7.3.0
         with:
           enable-cache: true
-          python-version: '3.14.0'
+          python-version: '3.14.3'
 
       - name: Install dependencies
         env:

--- a/.github/workflows/pyinstaller-macos_x86.yml
+++ b/.github/workflows/pyinstaller-macos_x86.yml
@@ -5,54 +5,46 @@ on:
     types: ["published"]
   push:
     branches: ["develop", "trunk"]
+  workflow_dispatch:
+
 permissions:
   contents: write
 jobs:
   build:
     # https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories
-    runs-on: macos-14
+    runs-on: macos-15-intel
     steps:
       - name: Checkout repository
-        uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3  # v6.0
-      - name: Set up Homebrew
-        id: set-up-homebrew
-        uses: Homebrew/actions/setup-homebrew@master
-      - name: Cache Homebrew Bundler RubyGems
-        id: cache
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830  # v4.3.0
-        with:
-          path: ${{ steps.set-up-homebrew.outputs.gems-path }}
-          key: ${{ runner.os }}-rubygems-${{ steps.set-up-homebrew.outputs.gems-hash }}
-          restore-keys: ${{ runner.os }}-rubygems-
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+
       - name: Install Homebrew Bundler RubyGems
-        if: steps.cache.outputs.cache-hit != 'true'
         run: brew install-bundler-gems
-      - name: Update Homebrew
-        id: update-homebrew
-        run: |
-          brew update
+
       # https://trac.ffmpeg.org/wiki/CompilationGuide/macOS#InstallingdependencieswithHomebrew
       - name: Get FFmpeg dependencies from Homebrew
         id: brew-install-ffmpeg-deps
         run: brew install automake nasm shtool xvid
+
       - name: Cache FFmpeg n7.0
         id: cache-ffmpeg
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830  # v4.3.0
+        uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306  # v5.0.3
         with:
           path: ${{ github.workspace }}/ffmpeg-n7.0
           key: ffmpeg-${{ hashFiles('ffmpeg-n7.0') }}
+
       - name: Clone FFmpeg, n7.0 tag
         if: ${{ steps.cache-ffmpeg.outputs.cache-hit != 'true' }}
         id: clone-ffmpeg-from-github
-        uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3  # v6.0
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           repository: FFmpeg/FFmpeg
           path: ffmpeg-n7.0
           ref: n7.0
           fetch-depth: 1
+
       - name: Build FFmpeg from source
+        working-directory: ./ffmpeg-n7.0
         run: |
-          cd ffmpeg-n7.0
           ./configure \
             --arch=x86_64 \
             --target-os=darwin \
@@ -80,47 +72,61 @@ jobs:
             --enable-protocol=file \
             --enable-small
             make -j"$(sysctl -n hw.logicalcpu)"
+
       - name: Set up Python
-        uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c  # v6.0
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
         with:
           architecture: "x64"
-          cache: "pip"
           check-latest: false
-          python-version: "3.12.10"
+          python-version: "3.14.3"
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
+          python-version: '3.14.3'
+
       - name: Install dependencies
+        env:
+          UV_NO_MANAGED_PYTHON: 1
         run: |
-          python3 -m pip install --upgrade pip pyinstaller setuptools wheel
-          python3 -m pip install --group build .
-          python3 -m pip install pyinstaller==6.7.0
+          uv sync --locked --group build --no-group dev
+
       - name: Create Executable with Pyinstaller
+        env:
+          UV_NO_MANAGED_PYTHON: 1
         run: |
-          pyinstaller \
+          uv run --no-project pyinstaller \
             --name tidal-wave_macos_amd64 \
             --target-arch=x86_64 \
             --paths src/tidal_wave \
             --exclude-module pyinstaller \
             --exclude-module ruff \
             --add-binary "ffmpeg-n7.0/ffmpeg:ffmpeg" \
+            --collect-all tzdata \
             --clean \
             --noupx \
             --onefile \
             --strip \
             ./pyinstaller.py
+
       - name: Test just-compiled binary
         run: |
           ./dist/tidal-wave_macos_amd64 --help
+
       - name: Upload Artifact
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f  # v6.0.0
         if: startsWith(github.ref, 'refs/tags/')
         with:
-          compression-level: 9
+          compression-level: 0
           name: tidal-wave_macos_amd64
           overwrite: true
           path: |
             ./dist/tidal-wave_macos_amd64
           retention-days: 7
+
       - name: Add artifact to release
-        uses: softprops/action-gh-release@6da8fa9354ddfdc4aeace5fc48d7f679b5214090  # v2.4.1
+        uses: softprops/action-gh-release@a06a81a03ee405af7f2048a818ed3f03bbf83c7b  # v2.5.0
         if: startsWith(github.ref, 'refs/tags/')
         with:
           fail_on_unmatched_files: true

--- a/.github/workflows/pyinstaller-macos_x86.yml
+++ b/.github/workflows/pyinstaller-macos_x86.yml
@@ -81,7 +81,7 @@ jobs:
           python-version: "3.14.3"
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@eac588ad8def6316056a12d4907a9d4d84ff7a3b  # v7.3.0
         with:
           enable-cache: true
           python-version: '3.14.3'

--- a/.github/workflows/pyinstaller-ubuntu_22_04.yml
+++ b/.github/workflows/pyinstaller-ubuntu_22_04.yml
@@ -21,7 +21,7 @@ jobs:
           DEBIAN_FRONTEND: noninteractive
         run: |
           sudo apt-get update -qq
-          sudo apt-get install --yes --no-install-recommends --no-install-suggests ccache g++ gcc git make pkg-config yasm
+          sudo apt-get install --yes --no-install-recommends --no-install-suggests ccache pkg-config yasm
 
       - name: Cache FFmpeg n7.0
         id: cache-ffmpeg
@@ -91,14 +91,17 @@ jobs:
           uv sync --locked --group build --no-group dev
 
       - name: Create Executable with PyInstaller
-        run: |
-          pyinstaller \
+        env:
+          UV_NO_MANAGED_PYTHON: 1
+        run: |  # tzdata in order to avoid PyInstaller error 'No time zone found with key UTC'
+          uv run --no-project pyinstaller \
             --name tidal-wave_ubuntu_22.04_amd64 \
             --target-arch=x86_64 \
             --paths src/tidal_wave \
             --exclude-module pyinstaller \
             --exclude-module ruff \
             --add-binary "ffmpeg-n7.0/ffmpeg:ffmpeg" \
+            --collect-all tzdata \
             --clean \
             --noupx \
             --onefile \

--- a/.github/workflows/pyinstaller-ubuntu_22_04.yml
+++ b/.github/workflows/pyinstaller-ubuntu_22_04.yml
@@ -12,28 +12,33 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout repository
-        uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0
-      - name: Install cached APT packages on Ubuntu
-        uses: awalsh128/cache-apt-pkgs-action@latest
-        with:
-          version: 1.0
-          packages: g++ gcc git make pkg-config yasm
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Install APT packages on Ubuntu
+        env:
+          DEBIAN_FRONTEND: noninteractive
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install --yes --no-install-recommends --no-install-suggests g++ gcc git make pkg-config yasm
+
       - name: Cache FFmpeg n7.0
         id: cache-ffmpeg
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830  # v4.3.0
+        uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306  # v5.0.3
         with:
           path: ${{ github.workspace }}/ffmpeg-n7.0
           key: ffmpeg-${{ hashFiles('ffmpeg-n7.0') }}
-      - name: Clone FFmpeg, n7.0 tag
-        if: ${{ steps.cache-ffmpeg.outputs.cache-hit != 'true' }}
+
+      - name: Clone FFmpeg, n7.0 tag, if not cached
+        if: steps.cache-ffmpeg.outputs.cache-hit != 'true'
         id: clone-ffmpeg-from-github
-        uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3  # v6.0
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: FFmpeg/FFmpeg
           path: ffmpeg-n7.0
           ref: n7.0
           fetch-depth: 1
-      - name: Build FFmpeg from source (git submodule)
+
+      - name: Build FFmpeg from source
         run: |
           cd ffmpeg-n7.0
           ./configure \
@@ -63,18 +68,21 @@ jobs:
             --enable-protocol=file \
             --enable-small
           make -j"$(nproc)"
+
       - name: Set up Python
-        uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c  # v6.0
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
         with:
           architecture: "x64"
           cache: "pip"
           check-latest: false
           python-version: "3.12.12"
+
       - name: Install dependencies
         run: |
-          python3 -m pip install --upgrade pip setuptools wheel
+          python3 -m pip install --upgrade pip
           python3 -m pip install --group build .
           python3 -m pip install pyinstaller==6.7.0
+
       - name: Create Executable with PyInstaller
         run: |
           pyinstaller \
@@ -89,22 +97,25 @@ jobs:
             --onefile \
             --strip \
             ./pyinstaller.py
+
       - name: Test just-compiled binary
         run: |
           chmod +x ./dist/tidal-wave_ubuntu_22.04_amd64
           ./dist/tidal-wave_ubuntu_22.04_amd64 --help
+
       - name: Upload Artifact
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f  # v6.0.0
         if: startsWith(github.ref, 'refs/tags/')
         with:
-          compression-level: 9
+          compression-level: 0  # binary is not really compressible; save CPU cycles, time
           name: tidal-wave_ubuntu
           overwrite: true
           path: |
             ./dist/tidal-wave_ubuntu_22.04_amd64
           retention-days: 7
+
       - name: Add artifact to release
-        uses: softprops/action-gh-release@6da8fa9354ddfdc4aeace5fc48d7f679b5214090  # v2.4.1
+        uses: softprops/action-gh-release@a06a81a03ee405af7f2048a818ed3f03bbf83c7b  # v2.5.0
         if: startsWith(github.ref, 'refs/tags/')
         with:
           fail_on_unmatched_files: true

--- a/.github/workflows/pyinstaller-ubuntu_22_04.yml
+++ b/.github/workflows/pyinstaller-ubuntu_22_04.yml
@@ -5,6 +5,8 @@ on:
     types: ["published"]
   push:
     branches: ["develop", "trunk"]
+  workflow_dispatch:
+
 permissions:
   contents: write
 jobs:
@@ -19,7 +21,7 @@ jobs:
           DEBIAN_FRONTEND: noninteractive
         run: |
           sudo apt-get update -qq
-          sudo apt-get install --yes --no-install-recommends --no-install-suggests g++ gcc git make pkg-config yasm
+          sudo apt-get install --yes --no-install-recommends --no-install-suggests ccache g++ gcc git make pkg-config yasm
 
       - name: Cache FFmpeg n7.0
         id: cache-ffmpeg
@@ -39,8 +41,8 @@ jobs:
           fetch-depth: 1
 
       - name: Build FFmpeg from source
+        working-directory: ./ffmpeg-n7.0
         run: |
-          cd ffmpeg-n7.0
           ./configure \
             --arch=x86_64 \
             --pkg-config-flags="--static" \
@@ -69,19 +71,24 @@ jobs:
             --enable-small
           make -j"$(nproc)"
 
-      - name: Set up Python
+      - name: "Set up Python"
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
         with:
           architecture: "x64"
-          cache: "pip"
           check-latest: false
-          python-version: "3.12.12"
+          python-version: '3.14.0'
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
+          python-version: '3.14.0'
 
       - name: Install dependencies
+        env:
+          UV_NO_MANAGED_PYTHON: 1
         run: |
-          python3 -m pip install --upgrade pip
-          python3 -m pip install --group build .
-          python3 -m pip install pyinstaller==6.7.0
+          uv sync --locked --group build --no-group dev
 
       - name: Create Executable with PyInstaller
         run: |

--- a/.github/workflows/pyinstaller-ubuntu_22_04.yml
+++ b/.github/workflows/pyinstaller-ubuntu_22_04.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: Install APT packages on Ubuntu
         env:
@@ -76,13 +76,13 @@ jobs:
         with:
           architecture: "x64"
           check-latest: false
-          python-version: '3.14.0'
+          python-version: '3.14.3'
 
       - name: Install uv
         uses: astral-sh/setup-uv@v7
         with:
           enable-cache: true
-          python-version: '3.14.0'
+          python-version: '3.14.3'
 
       - name: Install dependencies
         env:
@@ -100,6 +100,7 @@ jobs:
             --paths src/tidal_wave \
             --exclude-module pyinstaller \
             --exclude-module ruff \
+            --exclude-module uv \
             --add-binary "ffmpeg-n7.0/ffmpeg:ffmpeg" \
             --collect-all tzdata \
             --clean \

--- a/.github/workflows/pyinstaller-ubuntu_22_04.yml
+++ b/.github/workflows/pyinstaller-ubuntu_22_04.yml
@@ -79,7 +79,7 @@ jobs:
           python-version: '3.14.3'
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@eac588ad8def6316056a12d4907a9d4d84ff7a3b  # v7.3.0
         with:
           enable-cache: true
           python-version: '3.14.3'

--- a/.github/workflows/pyinstaller-ubuntu_24_04.yml
+++ b/.github/workflows/pyinstaller-ubuntu_24_04.yml
@@ -77,7 +77,7 @@ jobs:
           python-version: '3.14.3'
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@eac588ad8def6316056a12d4907a9d4d84ff7a3b  # v7.3.0
         with:
           enable-cache: true
           python-version: '3.14.3'

--- a/.github/workflows/pyinstaller-ubuntu_24_04.yml
+++ b/.github/workflows/pyinstaller-ubuntu_24_04.yml
@@ -74,7 +74,13 @@ jobs:
         with:
           architecture: "x64"
           check-latest: false
-          python-version: '3.14.0'
+          python-version: '3.14.3'
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
+          python-version: '3.14.3'
 
       - name: Install dependencies
         env:
@@ -92,6 +98,7 @@ jobs:
             --paths src/tidal_wave \
             --exclude-module pyinstaller \
             --exclude-module ruff \
+            --exclude-module uv \
             --add-binary "ffmpeg-n7.0/ffmpeg:ffmpeg" \
             --collect-all tzdata \
             --clean \

--- a/.github/workflows/pyinstaller-ubuntu_24_04.yml
+++ b/.github/workflows/pyinstaller-ubuntu_24_04.yml
@@ -12,30 +12,35 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout repository
-        uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0
-      - name: Install cached APT packages on Ubuntu
-        uses: awalsh128/cache-apt-pkgs-action@latest
-        with:
-          version: 1.0
-          packages: g++ gcc git make pkg-config yasm
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Install APT packages on Ubuntu
+        env:
+          DEBIAN_FRONTEND: noninteractive
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install --yes --no-install-recommends --no-install-suggests ccache pkg-config yasm
+
       - name: Cache FFmpeg n7.0
         id: cache-ffmpeg
         uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830  # v4.3.0
         with:
           path: ${{ github.workspace }}/ffmpeg-n7.0
           key: ffmpeg-${{ hashFiles('ffmpeg-n7.0') }}
+
       - name: Clone FFmpeg, n7.0 tag
         if: ${{ steps.cache-ffmpeg.outputs.cache-hit != 'true' }}
         id: clone-ffmpeg-from-github
-        uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: FFmpeg/FFmpeg
           path: ffmpeg-n7.0
           ref: n7.0
           fetch-depth: 1
+
       - name: Build FFmpeg from source (git submodule)
+        working-directory: ./ffmpeg-n7.0
         run: |
-          cd ffmpeg-n7.0
           ./configure \
             --arch=x86_64 \
             --pkg-config-flags="--static" \
@@ -63,48 +68,56 @@ jobs:
             --enable-protocol=file \
             --enable-small
           make -j"$(nproc)"
-      - name: Set up Python
-        uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c  # v6.0
+
+      - name: "Set up Python"
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
         with:
           architecture: "x64"
-          cache: "pip"
           check-latest: false
-          python-version: "3.12.12"
+          python-version: '3.14.0'
+
       - name: Install dependencies
+        env:
+          UV_NO_MANAGED_PYTHON: 1
         run: |
-          python3 -m pip install --upgrade pip setuptools wheel
-          python3 -m pip install --group build .
-          python3 -m pip install pyinstaller==6.7.0
+          uv sync --locked --group build --no-group dev
+
       - name: Create Executable with PyInstaller
-        run: |
-          pyinstaller \
-            --name tidal-wave_ubuntu_24.04_amd64 \
+        env:
+          UV_NO_MANAGED_PYTHON: 1
+        run: |  # tzdata in order to avoid PyInstaller error 'No time zone found with key UTC'
+          uv run --no-project pyinstaller \
+            --name tidal-wave_ubuntu_22.04_amd64 \
             --target-arch=x86_64 \
             --paths src/tidal_wave \
             --exclude-module pyinstaller \
             --exclude-module ruff \
             --add-binary "ffmpeg-n7.0/ffmpeg:ffmpeg" \
+            --collect-all tzdata \
             --clean \
             --noupx \
             --onefile \
             --strip \
             ./pyinstaller.py
+
       - name: Test just-compiled binary
         run: |
           chmod +x ./dist/tidal-wave_ubuntu_24.04_amd64
           ./dist/tidal-wave_ubuntu_24.04_amd64 --help
+
       - name: Upload Artifact
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f  # v6.0.0
         if: startsWith(github.ref, 'refs/tags/')
         with:
-          compression-level: 9
+          compression-level: 0
           name: tidal-wave_ubuntu
           overwrite: true
           path: |
             ./dist/tidal-wave_ubuntu_24.04_amd64
           retention-days: 7
+
       - name: Add artifact to release
-        uses: softprops/action-gh-release@6da8fa9354ddfdc4aeace5fc48d7f679b5214090  # v2.4.1
+        uses: softprops/action-gh-release@a06a81a03ee405af7f2048a818ed3f03bbf83c7b  # v2.5.0
         if: startsWith(github.ref, 'refs/tags/')
         with:
           fail_on_unmatched_files: true

--- a/.github/workflows/pyinstaller-windows.yml
+++ b/.github/workflows/pyinstaller-windows.yml
@@ -56,7 +56,7 @@ jobs:
           python-version: "3.14.3"
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@eac588ad8def6316056a12d4907a9d4d84ff7a3b  # v7.3.0
         with:
           enable-cache: true
           python-version: '3.14.3'

--- a/.github/workflows/pyinstaller-windows.yml
+++ b/.github/workflows/pyinstaller-windows.yml
@@ -5,6 +5,7 @@ on:
     types: ["published"]
   push:
     branches: ["develop", "trunk"]
+  workflow_dispatch:
 
 permissions:
   contents: write
@@ -14,77 +15,93 @@ jobs:
     runs-on: windows-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3  # v6.0
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+
       - name: Cache downloaded ffmpeg.exe
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830  # v4.3.0
+        uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306  # v5.0.3
         id: cache-ffmpeg-exe
         with:
           path: ${{ github.workspace }}\ffmpeg.exe
           key: ffmpeg-n7.0-from-media-autobuild-suite
+
       - name: Download ffmpeg binary if not found
         if: steps.cache-ffmpeg-exe.outputs.cache-hit != 'true'
         shell: pwsh
         run: |
           Invoke-WebRequest "https://github.com/ebb-earl-co/media-autobuild_suite/releases/download/n7.0/ffmpeg.exe" -OutFile "ffmpeg.exe"
+
       - name: Cache UPX 4.2.3 zip downloaded from GitHub
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830  # v4.3.0
+        uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306  # v5.0.3
         id: cache-upx-423
         with:
           path: ~\AppData\Local\upx-4.2.3-win64.zip
           key: upx-423-from-github
+
       - name: Download UPX binary if not found
         if: steps.cache-upx-423.outputs.cache-hit != 'true'
         shell: pwsh
         run: |
           Invoke-WebRequest "https://github.com/upx/upx/releases/download/v4.2.3/upx-4.2.3-win64.zip" -OutFile "~\AppData\Local\upx-4.2.3-win64.zip"
+
       - name: Install UPX tool
         shell: pwsh
         run: |
           Expand-Archive "~\AppData\Local\upx-4.2.3-win64.zip" -DestinationPath "~\AppData\Local\upx-4.2.3-win64"
+
       - name: Set up Python
-        uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c  # v6.0
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
         with:
           architecture: "x64"
-          cache: "pip"
-          python-version: "3.12.10"
-      - name: Install Python dependencies
-        shell: pwsh
+          check-latest: false
+          python-version: "3.14.3"
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
+          python-version: '3.14.3'
+
+      - name: Install dependencies
+        env:
+          UV_NO_MANAGED_PYTHON: 1
         run: |
-          python.exe -m venv .\venv
-          & .\venv\Scripts\activate
-          pip install --upgrade pip setuptools wheel
-          pip install .
-          pip install 'pypiwin32==223' 'pyinstaller==6.7.0'
+          uv.exe sync --locked --group build --no-group dev
+
       - name: Create Executable with Pyinstaller
+        env:
+          UV_NO_MANAGED_PYTHON: 1
         run: |
-          & .\venv\Scripts\activate
-          pyinstaller `
+          uv.exe run --no-project pyinstaller `
             --name tidal-wave_windows.exe `
             --paths src/tidal_wave `
             --add-binary "ffmpeg.exe;." `
             --exclude-module pyinstaller `
             --exclude-module ruff `
             --exclude-module uv `
+            --collect-all tzdata `
             --clean `
             --upx-dir "~\AppData\Local\upx-4.2.3-win64" `
             --onefile `
             .\pyinstaller.py
+
       - name: Test just-compiled binary
         shell: pwsh
         run: |
           & .\dist\tidal-wave_windows.exe --help
+
       - name: Upload Artifact
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f  # v6.0.0
         if: startsWith(github.ref, 'refs/tags/')
         with:
-          compression-level: 9
+          compression-level: 0
           name: tidal-wave_windows
           overwrite: true
           path: |
             .\dist\tidal-wave_windows.exe
           retention-days: 7
+
       - name: Add artifact to release
-        uses: softprops/action-gh-release@6da8fa9354ddfdc4aeace5fc48d7f679b5214090  # v2.4.1
+        uses: softprops/action-gh-release@a06a81a03ee405af7f2048a818ed3f03bbf83c7b  # v2.5.0
         if: startsWith(github.ref, 'refs/tags/')
         with:
           fail_on_unmatched_files: true

--- a/.github/workflows/python-build.yml
+++ b/.github/workflows/python-build.yml
@@ -17,20 +17,24 @@ jobs:
       id-token: write  # IMPORTANT: this permission is mandatory for trusted publishing
 
     steps:
-      - uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3  # v6.0
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - name: Set up Python
-        uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c  # v6.0
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
         with:
-          python-version: "3.13.9"
-          cache: "pip"
+          enable-cache: true
+          python-version: 3.14.0
 
       - name: Install dependencies
+        env:
+          UV_NO_MANAGED_PYTHON: 1
         run: |
-          python3 -m pip install --upgrade pip setuptools wheel build
+          uv sync --locked --no-group build --no-group dev
 
       - name: Build package
-        run: python3 -m build
+        env:
+          UV_NO_MANAGED_PYTHON: 1
+        run: uv build
 
       - name: Publish package
         uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e  # v1.13.0
@@ -39,7 +43,7 @@ jobs:
           password: ${{ secrets.PYPI_API_TOKEN }}
 
       - name: Add artifacts to release
-        uses: softprops/action-gh-release@6da8fa9354ddfdc4aeace5fc48d7f679b5214090  # v2.4.1
+        uses: softprops/action-gh-release@a06a81a03ee405af7f2048a818ed3f03bbf83c7b  # v2.5.0
         with:
           token: ${{ github.token }}
           files: |

--- a/.github/workflows/python-build.yml
+++ b/.github/workflows/python-build.yml
@@ -23,13 +23,13 @@ jobs:
       - name: "Set up Python"
         uses: actions/setup-python@v6.2.0
         with:
-          python-version: '3.14.0'
+          python-version: '3.14.3'
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@eac588ad8def6316056a12d4907a9d4d84ff7a3b  # v7.3.0
         with:
           enable-cache: true
-          python-version: '3.14.0'
+          python-version: '3.14.3'
 
       - name: Install dependencies
         env:

--- a/.github/workflows/python-build.yml
+++ b/.github/workflows/python-build.yml
@@ -20,11 +20,16 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
+      - name: "Set up Python"
+        uses: actions/setup-python@v6.2.0
+        with:
+          python-version: '3.14.0'
+
       - name: Install uv
         uses: astral-sh/setup-uv@v7
         with:
           enable-cache: true
-          python-version: 3.14.0
+          python-version: '3.14.0'
 
       - name: Install dependencies
         env:

--- a/.github/workflows/python-build.yml
+++ b/.github/workflows/python-build.yml
@@ -3,6 +3,7 @@ name: Build Python package
 on:
   release:
     types: ["published"]
+  workflow_dispatch:
 
 jobs:
   build:
@@ -38,12 +39,14 @@ jobs:
 
       - name: Publish package
         uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e  # v1.13.0
+        if: github.event_name != 'workflow_dispatch'
         with:
           user: __token__
           password: ${{ secrets.PYPI_API_TOKEN }}
 
       - name: Add artifacts to release
         uses: softprops/action-gh-release@a06a81a03ee405af7f2048a818ed3f03bbf83c7b  # v2.5.0
+        if: github.event_name != 'workflow_dispatch'
         with:
           token: ${{ github.token }}
           files: |

--- a/.github/workflows/python-lint.yml
+++ b/.github/workflows/python-lint.yml
@@ -5,24 +5,32 @@ on:
     branches: ["trunk", "develop"]
   pull_request:
     branches: ["trunk", "develop"]
+  workflow_dispatch:
+
 permissions:
   contents: read
 jobs:
   build:
     strategy:
       matrix:
-        version: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.13t"]
+        version: ["3.10", "3.11", "3.12", "3.13", "3.13t", "3.14", "3.14t"]
         # https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories
         os: [ubuntu-22.04, ubuntu-24.04, windows-2022, windows-2025, macos-14, macos-15, macos-26]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3  # v6.0
+      - name: Check out repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+
       - name: Install uv
         uses: astral-sh/setup-uv@3259c6206f993105e3a61b142c2d97bf4b9ef83d  # v7.1.0
         with:
+          cache-python: "true"
+          enable-cache: "true"
           python-version: ${{ matrix.version }}
-          version: ">=0.9"
+          version-file: "pyproject.toml"
+
       - name: Format with Ruff
-        run: uv run --no-project --with ruff ruff format --diff ./tidal_wave/
+        run: uv run --no-project --with ruff ruff format --diff ./src/tidal_wave/
+
       - name: Lint with Ruff
-        run: uv run --no-project --with ruff ruff check --statistics --exclude pyinstaller.py ./tidal_wave/
+        run: uv run --no-project --with ruff ruff check --statistics --exclude pyinstaller.py ./src/tidal_wave/

--- a/.github/workflows/python-lint.yml
+++ b/.github/workflows/python-lint.yml
@@ -22,7 +22,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: Install uv
-        uses: astral-sh/setup-uv@3259c6206f993105e3a61b142c2d97bf4b9ef83d  # v7.1.0
+        uses: astral-sh/setup-uv@eac588ad8def6316056a12d4907a9d4d84ff7a3b  # v7.3.0
         with:
           cache-python: "true"
           enable-cache: "true"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,7 +14,7 @@ repos:
 
 - repo: https://github.com/astral-sh/ruff-pre-commit
   # Ruff version.
-  rev: v0.14.5
+  rev: v0.15.4
   hooks:
     # Run the linter.
     - id: ruff-check

--- a/hooks/version-match.py
+++ b/hooks/version-match.py
@@ -3,21 +3,21 @@
 from pathlib import Path
 from re import Match, search
 from sys import exit, stderr, version_info
-from typing import Any, Dict, Optional, Tuple
+from typing import Any
 
 if __name__ == "__main__":
-    vi: Tuple[int, int] = version_info[:2]
+    vi: tuple[int, int] = version_info[:2]
     if vi < (3, 11):
         from pip._vendor import tomli as tomllib
     else:
         import tomllib
 
-    pyproject_toml: Dict[str, Any] = tomllib.loads(Path("pyproject.toml").read_text())
-    pyproject_toml_version: Optional[str] = pyproject_toml.get(
+    pyproject_toml: dict[str, Any] = tomllib.loads(Path("pyproject.toml").read_text())
+    pyproject_toml_version: str | None = pyproject_toml.get(
         "project", {"version": None}
     ).get("version")
 
-    pyinstaller_version_match: Optional[Match] = search(
+    pyinstaller_version_match: Match | None = search(
         pyproject_toml_version, Path("pyinstaller.py").read_text()
     )
     if pyinstaller_version_match is None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ dependencies = [
     "requests[socks]>=2.32.4",  # CVE-2024-47081
     "typer==0.23.1",
     "tzdata==2025.3",
-    "urllib>=2.6.3"  # CVE-2026-21441
+    "urllib3>=2.6.3"  # CVE-2026-21441
 ]
 [project.scripts]
 tidal-wave = "tidal_wave.main:app"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ authors = [{ name = "colinho", email = "pypi@colin.technology" }]
 maintainers = [{ name = "colinho", email = "pypi@colin.technology" }]
 license-files = ["LICENSE"]
 readme = { file = "README.md", content-type = "text/markdown" }
-requires-python = ">=3.9, <3.15"
+requires-python = ">=3.10, <3.15"
 version = "2025.11.1"
 classifiers = [
     "Intended Audience :: End Users/Desktop",
@@ -64,4 +64,4 @@ quote-style = "double"
 [tool.uv]
 compile-bytecode = true  # https://docs.astral.sh/uv/reference/settings/#compile-bytecode
 package = true  # https://docs.astral.sh/uv/reference/settings/#package
-required-version = ">=0.9"  # https://docs.astral.sh/uv/reference/settings/#required-version
+required-version = ">=0.10"  # https://docs.astral.sh/uv/reference/settings/#required-version

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["uv_build>=0.9.4,<0.10.0"]
+requires = ["uv_build>=0.9.4,<0.10.7"]
 build-backend = "uv_build"
 [project]
 name = "tidal-wave"
@@ -25,16 +25,16 @@ classifiers = [
 ]
 dependencies = [
     "backoff==2.2.1",
-    "cachecontrol==0.14.2",
-    "dataclass-wizard==0.35.1",
+    "cachecontrol==0.14.3",
+    "dataclass-wizard==0.39.1",
     "ffmpeg-python==0.2.0",
     "mutagen==1.47.0",
     "m3u8==6.0.0",
-    "platformdirs==4.3.8",
+    "platformdirs==4.5.1",
     "pycryptodome==3.23.0",
     "requests[socks]>=2.32.4",  # CVE-2024-47081
-    "typer==0.20.0",
-    "tzdata==2025.2; platform_system == 'Windows'",
+    "typer==0.23.1",
+    "tzdata==2025.3; platform_system == 'Windows'",
 ]
 [project.scripts]
 tidal-wave = "tidal_wave.main:app"

--- a/src/tidal_wave/login.py
+++ b/src/tidal_wave/login.py
@@ -12,6 +12,7 @@ from typing import TYPE_CHECKING
 import requests
 import typer
 
+from .media import AudioFormat
 from .models import BearerAuth, SessionsEndpointResponseJSON
 from .oauth import (
     TOKEN_DIR_PATH,
@@ -29,16 +30,6 @@ COMMON_HEADERS: dict[str, str] = {"Accept-Encoding": "gzip, deflate, br"}
 COUNTRY_CODE_PROPER_LENGTH: int = 2
 
 logger = logging.getLogger(__name__)
-
-
-class AudioFormat(str, Enum):
-    """A simple representation of TIDAL's music quality levels."""
-
-    dolby_atmos = "Atmos"
-    hi_res = "HiRes"
-    lossless = "Lossless"
-    high = "High"
-    low = "Low"
 
 
 class LogLevel(str, Enum):
@@ -59,7 +50,7 @@ def load_token_from_disk(
         _msg: str = f"FileNotFoundError: {token_path.absolute()}"
         logger.warning(_msg)
         return None
-    token_file_contents: str = token_path.read_bytes()
+    token_file_contents: bytes = token_path.read_bytes()
     decoded_token_file_contents: str = base64.b64decode(token_file_contents).decode(
         "utf-8",
     )
@@ -105,7 +96,7 @@ def validate_token_for_session(
         logger.debug("Adding data from API reponse to session object:")
         logger.debug(serj)
 
-    sess: requests.Session = requests.Session()
+    sess = requests.Session()
     sess.headers = headers
     sess.auth = BearerAuth(token=token)
     sess.user_id = serj.user_id
@@ -177,7 +168,7 @@ def login_android(
 
     if access_token is None:
         logger.warning("Could not load access token from disk")
-        access_token: str = typer.prompt(
+        access_token = typer.prompt(
             "Enter TIDAL access token from an Android (the part after 'Bearer ')",
         )
         dt_input: str = typer.prompt(
@@ -227,7 +218,7 @@ def login_windows(
     _token: dict | None = load_token_from_disk(token_path=token_path)
     access_token: str | None = None if _token is None else _token.get("access_token")
     if access_token is None:
-        access_token: str = typer.prompt(
+        access_token = typer.prompt(
             "Enter TIDAL API access token (the part after 'Bearer ')",
         )
 
@@ -267,7 +258,7 @@ def login_macos(
     _token: dict | None = load_token_from_disk(token_path=token_path)
     access_token: str | None = None if _token is None else _token.get("access_token")
     if access_token is None:
-        access_token: str = typer.prompt(
+        access_token = typer.prompt(
             "Enter TIDAL API access token (the part after 'Bearer ')",
         )
 
@@ -307,13 +298,15 @@ def login(
     Return a tuple of a requests.Session object, if no error, and the
     AudioFormat instance passed in; or (None, "") in the event of error.
     """
-    high_quality_formats: set[AudioFormat] = {AudioFormat.hi_res}
-    fire_tv_formats: set[AudioFormat] = {
-        AudioFormat.dolby_atmos,
-        AudioFormat.lossless,
-        AudioFormat.high,
-        AudioFormat.low,
-    }
+    high_quality_formats: frozenset[AudioFormat] = frozenset((AudioFormat.hi_res,))
+    fire_tv_formats: frozenset[AudioFormat] = frozenset(
+        (
+            AudioFormat.dolby_atmos,
+            AudioFormat.lossless,
+            AudioFormat.high,
+            AudioFormat.low,
+        )
+    )
     if audio_format in fire_tv_formats:
         return (login_fire_tv(), audio_format)
 
@@ -326,7 +319,9 @@ def login(
         if (TOKEN_DIR_PATH / "mac_os-tidal.token").exists():
             return (login_macos(), audio_format)
 
-        options: set = {"android", "a", "macos", "m", "windows", "w"}
+        options: frozenset[str] = frozenset(
+            ("android", "a", "macos", "m", "windows", "w")
+        )
         _input: str = ""
         while _input not in options:
             _input = typer.prompt(
@@ -334,7 +329,7 @@ def login(
                 "to provide an API token?",
             ).lower()
 
-        _to_return: tuple[None, str] = (None, "")
+        _to_return: tuple[requests.Session | None, str] = (None, "")
 
         if _input in {"android", "a"}:
             _to_return = (login_android(), audio_format)

--- a/src/tidal_wave/media.py
+++ b/src/tidal_wave/media.py
@@ -1,7 +1,5 @@
 """Represent various media metadata and formats."""
 
-from __future__ import annotations
-
 from enum import Enum
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -569,6 +569,7 @@ dependencies = [
     { name = "requests", extra = ["socks"] },
     { name = "typer" },
     { name = "tzdata" },
+    { name = "urllib3" },
 ]
 
 [package.dev-dependencies]
@@ -592,9 +593,8 @@ requires-dist = [
     { name = "pycryptodome", specifier = "==3.23.0" },
     { name = "requests", extras = ["socks"], specifier = ">=2.32.4" },
     { name = "typer", specifier = "==0.23.1" },
-    { name = "tzdata", marker = "sys_platform == 'win32'", specifier = "==2025.3" },
-    { name = "typer", specifier = "==0.20.0" },
-    { name = "tzdata", specifier = "==2025.2" },
+    { name = "tzdata", specifier = "==2025.3" },
+    { name = "urllib3", specifier = ">=2.6.3" },
 ]
 
 [package.metadata.requires-dev]
@@ -639,9 +639,9 @@ wheels = [
 
 [[package]]
 name = "urllib3"
-version = "2.3.0"
+version = "2.6.3"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/aa/63/e53da845320b757bf29ef6a9062f5c669fe997973f966045cb019c3f4b66/urllib3-2.3.0.tar.gz", hash = "sha256:f8c5449b3cf0861679ce7e0503c7b44b5ec981bec0d1d3795a07f1ba96f0204d", size = 307268, upload-time = "2024-12-22T07:47:30.032Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c7/24/5f1b3bdffd70275f6661c76461e25f024d5a38a46f04aaca912426a2b1d3/urllib3-2.6.3.tar.gz", hash = "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed", size = 435556, upload-time = "2026-01-07T16:24:43.925Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c8/19/4ec628951a74043532ca2cf5d97b7b14863931476d117c471e8e2b1eb39f/urllib3-2.3.0-py3-none-any.whl", hash = "sha256:1cee9ad369867bfdbbb48b7dd50374c0967a0bb7710050facf0dd6911440e3df", size = 128369, upload-time = "2024-12-22T07:47:28.074Z" },
+    { url = "https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl", hash = "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4", size = 131584, upload-time = "2026-01-07T16:24:42.685Z" },
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -1,6 +1,6 @@
 version = 1
 revision = 3
-requires-python = ">=3.9, <3.15"
+requires-python = ">=3.10, <3.15"
 
 [[package]]
 name = "altgraph"
@@ -9,6 +9,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/de/a8/7145824cf0b9e3c28046520480f207df47e927df83aa9555fb47f8505922/altgraph-0.17.4.tar.gz", hash = "sha256:1b5afbb98f6c4dcadb2e2ae6ab9fa994bbb8c1d75f4fa96d340f9437ae454406", size = 48418, upload-time = "2023-09-25T09:04:52.164Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/4d/3f/3bc3f1d83f6e4a7fcb834d3720544ca597590425be5ba9db032b2bf322a2/altgraph-0.17.4-py2.py3-none-any.whl", hash = "sha256:642743b4750de17e655e6711601b077bc6598dbfa3ba5fa2b2a35ce12b508dff", size = 21212, upload-time = "2023-09-25T09:04:50.691Z" },
+]
+
+[[package]]
+name = "annotated-doc"
+version = "0.0.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/57/ba/046ceea27344560984e26a590f90bc7f4a75b06701f653222458922b558c/annotated_doc-0.0.4.tar.gz", hash = "sha256:fbcda96e87e9c92ad167c2e53839e57503ecfda18804ea28102353485033faa4", size = 7288, upload-time = "2025-11-10T22:07:42.062Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1e/d3/26bf1008eb3d2daa8ef4cacc7f3bfdc11818d111f7e2d0201bc6e3b49d45/annotated_doc-0.0.4-py3-none-any.whl", hash = "sha256:571ac1dc6991c450b25a9c2d84a3705e2ae7a53467b5d111c24fa8baabbed320", size = 5303, upload-time = "2025-11-10T22:07:40.673Z" },
 ]
 
 [[package]]
@@ -50,31 +59,21 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/f6/0a/4b34a838c57bd16d3e5861ab963845e73a1041034651f7459e9935289cfd/backports_datetime_fromisoformat-2.0.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:620e8e73bd2595dfff1b4d256a12b67fce90ece3de87b38e1dde46b910f46f4d", size = 55353, upload-time = "2024-12-28T20:17:32.433Z" },
     { url = "https://files.pythonhosted.org/packages/d9/68/07d13c6e98e1cad85606a876367ede2de46af859833a1da12c413c201d78/backports_datetime_fromisoformat-2.0.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:4cf9c0a985d68476c1cabd6385c691201dda2337d7453fb4da9679ce9f23f4e7", size = 55298, upload-time = "2024-12-28T20:17:34.919Z" },
     { url = "https://files.pythonhosted.org/packages/60/33/45b4d5311f42360f9b900dea53ab2bb20a3d61d7f9b7c37ddfcb3962f86f/backports_datetime_fromisoformat-2.0.3-cp312-cp312-win_amd64.whl", hash = "sha256:d144868a73002e6e2e6fef72333e7b0129cecdd121aa8f1edba7107fd067255d", size = 29375, upload-time = "2024-12-28T20:17:36.018Z" },
-    { url = "https://files.pythonhosted.org/packages/36/bf/990ac5a4f86fdb92d435511bb80a9e66f0a8dd87e76ae00dd062db2cf649/backports_datetime_fromisoformat-2.0.3-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:fa2de871801d824c255fac7e5e7e50f2be6c9c376fd9268b40c54b5e9da91f42", size = 27548, upload-time = "2024-12-28T20:17:55.065Z" },
-    { url = "https://files.pythonhosted.org/packages/c6/e8/8f49cfc187df0231a1c1bcf780bbdb3d1c391dccafc3510cd033b637f836/backports_datetime_fromisoformat-2.0.3-cp39-cp39-macosx_11_0_universal2.whl", hash = "sha256:1314d4923c1509aa9696712a7bc0c7160d3b7acf72adafbbe6c558d523f5d491", size = 34445, upload-time = "2024-12-28T20:17:56.134Z" },
-    { url = "https://files.pythonhosted.org/packages/06/25/4ac60683f383d51337620ef6f5ff56438174b18f5d6a66f71da2ea4acd26/backports_datetime_fromisoformat-2.0.3-cp39-cp39-macosx_11_0_x86_64.whl", hash = "sha256:b750ecba3a8815ad8bc48311552f3f8ab99dd2326d29df7ff670d9c49321f48f", size = 27093, upload-time = "2024-12-28T20:17:57.17Z" },
-    { url = "https://files.pythonhosted.org/packages/c7/ea/561edac54f9a1440a4bce0aecc291e5155e734ab42db88ce24cd1cccf288/backports_datetime_fromisoformat-2.0.3-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b2d5117dce805d8a2f78baeddc8c6127281fa0a5e2c40c6dd992ba6b2b367876", size = 52352, upload-time = "2024-12-28T20:17:59.642Z" },
-    { url = "https://files.pythonhosted.org/packages/43/aa/98ed742a9a1bd88f5ead7852eb1d2fc828cba96b46340b70fc216a7f4b70/backports_datetime_fromisoformat-2.0.3-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fb35f607bd1cbe37b896379d5f5ed4dc298b536f4b959cb63180e05cacc0539d", size = 52314, upload-time = "2024-12-28T20:18:00.771Z" },
-    { url = "https://files.pythonhosted.org/packages/c7/ab/5b8f8c0be6a563f00bf2ecefff18beb6daf1e78025c0d823f581bf0a879f/backports_datetime_fromisoformat-2.0.3-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:61c74710900602637d2d145dda9720c94e303380803bf68811b2a151deec75c2", size = 52488, upload-time = "2024-12-28T20:18:01.888Z" },
-    { url = "https://files.pythonhosted.org/packages/20/14/fef93556a022530525c77729f94eab3452568a11f7893cbcd76e06b398e8/backports_datetime_fromisoformat-2.0.3-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:ece59af54ebf67ecbfbbf3ca9066f5687879e36527ad69d8b6e3ac565d565a62", size = 52555, upload-time = "2024-12-28T20:18:03.065Z" },
-    { url = "https://files.pythonhosted.org/packages/2f/bf/e1a2fe6ec0ce2b983d7cc93c43b41334f595fd7793aa35afbd02737c5e75/backports_datetime_fromisoformat-2.0.3-cp39-cp39-win_amd64.whl", hash = "sha256:d0a7c5f875068efe106f62233bc712d50db4d07c13c7db570175c7857a7b5dbd", size = 29331, upload-time = "2024-12-28T20:18:05.494Z" },
     { url = "https://files.pythonhosted.org/packages/be/03/7eaa9f9bf290395d57fd30d7f1f2f9dff60c06a31c237dc2beb477e8f899/backports_datetime_fromisoformat-2.0.3-pp310-pypy310_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:90e202e72a3d5aae673fcc8c9a4267d56b2f532beeb9173361293625fe4d2039", size = 28980, upload-time = "2024-12-28T20:18:06.554Z" },
     { url = "https://files.pythonhosted.org/packages/47/80/a0ecf33446c7349e79f54cc532933780341d20cff0ee12b5bfdcaa47067e/backports_datetime_fromisoformat-2.0.3-pp310-pypy310_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2df98ef1b76f5a58bb493dda552259ba60c3a37557d848e039524203951c9f06", size = 28449, upload-time = "2024-12-28T20:18:07.77Z" },
-    { url = "https://files.pythonhosted.org/packages/93/a3/ef965bee678d5dfbabfd85283d8a9caf125b11c394174eceb76707e64334/backports_datetime_fromisoformat-2.0.3-pp39-pypy39_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f2797593760da6bcc32c4a13fa825af183cd4bfd333c60b3dbf84711afca26ef", size = 28978, upload-time = "2024-12-28T20:18:12.441Z" },
-    { url = "https://files.pythonhosted.org/packages/dc/e7/910935727b5c0e4975820d0ae5c9489d111859c651109f72208a8a28105b/backports_datetime_fromisoformat-2.0.3-pp39-pypy39_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:35a144fd681a0bea1013ccc4cd3fd4dc758ea17ee23dca019c02b82ec46fc0c4", size = 28437, upload-time = "2024-12-28T20:18:13.465Z" },
 ]
 
 [[package]]
 name = "cachecontrol"
-version = "0.14.2"
+version = "0.14.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "msgpack" },
     { name = "requests" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/b7/a4/3390ac4dfa1773f661c8780368018230e8207ec4fd3800d2c0c3adee4456/cachecontrol-0.14.2.tar.gz", hash = "sha256:7d47d19f866409b98ff6025b6a0fca8e4c791fb31abbd95f622093894ce903a2", size = 28832, upload-time = "2025-01-07T15:48:23.709Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/58/3a/0cbeb04ea57d2493f3ec5a069a117ab467f85e4a10017c6d854ddcbff104/cachecontrol-0.14.3.tar.gz", hash = "sha256:73e7efec4b06b20d9267b441c1f733664f989fb8688391b670ca812d70795d11", size = 28985, upload-time = "2025-04-30T16:45:06.135Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c8/63/baffb44ca6876e7b5fc8fe17b24a7c07bf479d604a592182db9af26ea366/cachecontrol-0.14.2-py3-none-any.whl", hash = "sha256:ebad2091bf12d0d200dfc2464330db638c5deb41d546f6d7aca079e87290f3b0", size = 21780, upload-time = "2025-01-07T15:48:21.034Z" },
+    { url = "https://files.pythonhosted.org/packages/81/4c/800b0607b00b3fd20f1087f80ab53d6b4d005515b0f773e4831e37cfa83f/cachecontrol-0.14.3-py3-none-any.whl", hash = "sha256:b35e44a3113f17d2a31c1e6b27b9de6d4405f84ae51baa8c1d3cc5b633010cae", size = 21802, upload-time = "2025-04-30T16:45:03.863Z" },
 ]
 
 [[package]]
@@ -144,19 +143,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/e4/93/946a86ce20790e11312c87c75ba68d5f6ad2208cfb52b2d6a2c32840d922/charset_normalizer-3.4.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:fa88b843d6e211393a37219e6a1c1df99d35e8fd90446f1118f4216e307e48cd", size = 145732, upload-time = "2024-12-24T18:11:22.774Z" },
     { url = "https://files.pythonhosted.org/packages/cd/e5/131d2fb1b0dddafc37be4f3a2fa79aa4c037368be9423061dccadfd90091/charset_normalizer-3.4.1-cp313-cp313-win32.whl", hash = "sha256:eb8178fe3dba6450a3e024e95ac49ed3400e506fd4e9e5c32d30adda88cbd407", size = 95391, upload-time = "2024-12-24T18:11:24.139Z" },
     { url = "https://files.pythonhosted.org/packages/27/f2/4f9a69cc7712b9b5ad8fdb87039fd89abba997ad5cbe690d1835d40405b0/charset_normalizer-3.4.1-cp313-cp313-win_amd64.whl", hash = "sha256:b1ac5992a838106edb89654e0aebfc24f5848ae2547d22c2c3f66454daa11971", size = 102702, upload-time = "2024-12-24T18:11:26.535Z" },
-    { url = "https://files.pythonhosted.org/packages/7f/c0/b913f8f02836ed9ab32ea643c6fe4d3325c3d8627cf6e78098671cafff86/charset_normalizer-3.4.1-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:b97e690a2118911e39b4042088092771b4ae3fc3aa86518f84b8cf6888dbdb41", size = 197867, upload-time = "2024-12-24T18:12:10.438Z" },
-    { url = "https://files.pythonhosted.org/packages/0f/6c/2bee440303d705b6fb1e2ec789543edec83d32d258299b16eed28aad48e0/charset_normalizer-3.4.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:78baa6d91634dfb69ec52a463534bc0df05dbd546209b79a3880a34487f4b84f", size = 141385, upload-time = "2024-12-24T18:12:11.847Z" },
-    { url = "https://files.pythonhosted.org/packages/3d/04/cb42585f07f6f9fd3219ffb6f37d5a39b4fd2db2355b23683060029c35f7/charset_normalizer-3.4.1-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:1a2bc9f351a75ef49d664206d51f8e5ede9da246602dc2d2726837620ea034b2", size = 151367, upload-time = "2024-12-24T18:12:13.177Z" },
-    { url = "https://files.pythonhosted.org/packages/54/54/2412a5b093acb17f0222de007cc129ec0e0df198b5ad2ce5699355269dfe/charset_normalizer-3.4.1-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:75832c08354f595c760a804588b9357d34ec00ba1c940c15e31e96d902093770", size = 143928, upload-time = "2024-12-24T18:12:14.497Z" },
-    { url = "https://files.pythonhosted.org/packages/5a/6d/e2773862b043dcf8a221342954f375392bb2ce6487bcd9f2c1b34e1d6781/charset_normalizer-3.4.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0af291f4fe114be0280cdd29d533696a77b5b49cfde5467176ecab32353395c4", size = 146203, upload-time = "2024-12-24T18:12:15.731Z" },
-    { url = "https://files.pythonhosted.org/packages/b9/f8/ca440ef60d8f8916022859885f231abb07ada3c347c03d63f283bec32ef5/charset_normalizer-3.4.1-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:0167ddc8ab6508fe81860a57dd472b2ef4060e8d378f0cc555707126830f2537", size = 148082, upload-time = "2024-12-24T18:12:18.641Z" },
-    { url = "https://files.pythonhosted.org/packages/04/d2/42fd330901aaa4b805a1097856c2edf5095e260a597f65def493f4b8c833/charset_normalizer-3.4.1-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:2a75d49014d118e4198bcee5ee0a6f25856b29b12dbf7cd012791f8a6cc5c496", size = 142053, upload-time = "2024-12-24T18:12:20.036Z" },
-    { url = "https://files.pythonhosted.org/packages/9e/af/3a97a4fa3c53586f1910dadfc916e9c4f35eeada36de4108f5096cb7215f/charset_normalizer-3.4.1-cp39-cp39-musllinux_1_2_i686.whl", hash = "sha256:363e2f92b0f0174b2f8238240a1a30142e3db7b957a5dd5689b0e75fb717cc78", size = 150625, upload-time = "2024-12-24T18:12:22.804Z" },
-    { url = "https://files.pythonhosted.org/packages/26/ae/23d6041322a3556e4da139663d02fb1b3c59a23ab2e2b56432bd2ad63ded/charset_normalizer-3.4.1-cp39-cp39-musllinux_1_2_ppc64le.whl", hash = "sha256:ab36c8eb7e454e34e60eb55ca5d241a5d18b2c6244f6827a30e451c42410b5f7", size = 153549, upload-time = "2024-12-24T18:12:24.163Z" },
-    { url = "https://files.pythonhosted.org/packages/94/22/b8f2081c6a77cb20d97e57e0b385b481887aa08019d2459dc2858ed64871/charset_normalizer-3.4.1-cp39-cp39-musllinux_1_2_s390x.whl", hash = "sha256:4c0907b1928a36d5a998d72d64d8eaa7244989f7aaaf947500d3a800c83a3fd6", size = 150945, upload-time = "2024-12-24T18:12:25.415Z" },
-    { url = "https://files.pythonhosted.org/packages/c7/0b/c5ec5092747f801b8b093cdf5610e732b809d6cb11f4c51e35fc28d1d389/charset_normalizer-3.4.1-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:04432ad9479fa40ec0f387795ddad4437a2b50417c69fa275e212933519ff294", size = 146595, upload-time = "2024-12-24T18:12:28.03Z" },
-    { url = "https://files.pythonhosted.org/packages/0c/5a/0b59704c38470df6768aa154cc87b1ac7c9bb687990a1559dc8765e8627e/charset_normalizer-3.4.1-cp39-cp39-win32.whl", hash = "sha256:3bed14e9c89dcb10e8f3a29f9ccac4955aebe93c71ae803af79265c9ca5644c5", size = 95453, upload-time = "2024-12-24T18:12:29.569Z" },
-    { url = "https://files.pythonhosted.org/packages/85/2d/a9790237cb4d01a6d57afadc8573c8b73c609ade20b80f4cda30802009ee/charset_normalizer-3.4.1-cp39-cp39-win_amd64.whl", hash = "sha256:49402233c892a461407c512a19435d1ce275543138294f7ef013f0b63d5d3765", size = 102811, upload-time = "2024-12-24T18:12:30.83Z" },
     { url = "https://files.pythonhosted.org/packages/0e/f6/65ecc6878a89bb1c23a086ea335ad4bf21a588990c3f535a227b9eea9108/charset_normalizer-3.4.1-py3-none-any.whl", hash = "sha256:d98b1668f06378c6dbefec3b92299716b931cd4e6061f3c875a71ced1780ab85", size = 49767, upload-time = "2024-12-24T18:12:32.852Z" },
 ]
 
@@ -183,14 +169,14 @@ wheels = [
 
 [[package]]
 name = "dataclass-wizard"
-version = "0.35.1"
+version = "0.39.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "typing-extensions", marker = "python_full_version < '3.13'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/f2/61/c432fc30841214df594c82e7c39dd8e46f6c60357b16d5e578e6258b178c/dataclass-wizard-0.35.1.tar.gz", hash = "sha256:18c780e3c574c3534cb2bbc447025cff140f0e640cd98e143a7d234c6445d09e", size = 295591, upload-time = "2025-07-27T21:54:05.351Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/36/ea/6b2811092feecbe9d672e3641196ac5fcbec6664074da5dec8b9fd9b9059/dataclass_wizard-0.39.1.tar.gz", hash = "sha256:1679948ed7c62103f40b34df97d03b35e6b2ad50f58173fdbe30074e2e4730f2", size = 361190, upload-time = "2026-01-06T03:30:57.054Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/49/34/a66cfdd36d9155800c00800211ecc75059db71ad3e79100b50929ed87af0/dataclass_wizard-0.35.1-py2.py3-none-any.whl", hash = "sha256:30858e14d780a40792fa190d55220a12cd0ef02a3d8fb8373b1eb4363d4b5549", size = 176536, upload-time = "2025-07-27T21:54:03.47Z" },
+    { url = "https://files.pythonhosted.org/packages/27/a0/a221942b3fbbafaea4e211744d298366b6a9712c1aa336b05fc1c865ac0c/dataclass_wizard-0.39.1-py3-none-any.whl", hash = "sha256:3324e59eca705882eb34e2b3989b2beadd8c2b523e6269d4002cf1a4a5bf703b", size = 215344, upload-time = "2026-01-06T03:30:54.915Z" },
 ]
 
 [[package]]
@@ -221,18 +207,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f1/70/7703c29685631f5a7590aa73f1f1d3fa9a380e654b86af429e0934a32f7d/idna-3.10.tar.gz", hash = "sha256:12f65c9b470abda6dc35cf8e63cc574b1c52b11df2c86030af0ac09b01b13ea9", size = 190490, upload-time = "2024-09-15T18:07:39.745Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/76/c6/c88e154df9c4e1a2a66ccf0005a88dfb2650c1dffb6f5ce603dfbd452ce3/idna-3.10-py3-none-any.whl", hash = "sha256:946d195a0d259cbba61165e88e65941f16e9b36ea6ddb97f00452bae8b1287d3", size = 70442, upload-time = "2024-09-15T18:07:37.964Z" },
-]
-
-[[package]]
-name = "importlib-metadata"
-version = "8.6.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "zipp" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/33/08/c1395a292bb23fd03bdf572a1357c5a733d3eecbab877641ceacab23db6e/importlib_metadata-8.6.1.tar.gz", hash = "sha256:310b41d755445d74569f993ccfc22838295d9fe005425094fad953d7f15c8580", size = 55767, upload-time = "2025-01-20T22:21:30.429Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/79/9d/0fb148dc4d6fa4a7dd1d8378168d9b4cd8d4560a6fbf6f0121c5fc34eb68/importlib_metadata-8.6.1-py3-none-any.whl", hash = "sha256:02a89390c1e15fdfdc0d7c6b25cb3e62650d0494005c97d6f148bf5b9787525e", size = 26971, upload-time = "2025-01-20T22:21:29.177Z" },
 ]
 
 [[package]]
@@ -330,17 +304,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/7a/40/631c238f1f338eb09f4acb0f34ab5862c4e9d7eda11c1b685471a4c5ea37/msgpack-1.1.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:b4c01941fd2ff87c2a934ee6055bda4ed353a7846b8d4f341c428109e9fcde8c", size = 399082, upload-time = "2024-09-10T04:25:18.398Z" },
     { url = "https://files.pythonhosted.org/packages/e9/1b/fa8a952be252a1555ed39f97c06778e3aeb9123aa4cccc0fd2acd0b4e315/msgpack-1.1.0-cp313-cp313-win32.whl", hash = "sha256:7c9a35ce2c2573bada929e0b7b3576de647b0defbd25f5139dcdaba0ae35a4cc", size = 69037, upload-time = "2024-09-10T04:24:52.798Z" },
     { url = "https://files.pythonhosted.org/packages/b6/bc/8bd826dd03e022153bfa1766dcdec4976d6c818865ed54223d71f07862b3/msgpack-1.1.0-cp313-cp313-win_amd64.whl", hash = "sha256:bce7d9e614a04d0883af0b3d4d501171fbfca038f12c77fa838d9f198147a23f", size = 75140, upload-time = "2024-09-10T04:24:31.288Z" },
-    { url = "https://files.pythonhosted.org/packages/f7/3b/544a5c5886042b80e1f4847a4757af3430f60d106d8d43bb7be72c9e9650/msgpack-1.1.0-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:53258eeb7a80fc46f62fd59c876957a2d0e15e6449a9e71842b6d24419d88ca1", size = 150713, upload-time = "2024-09-10T04:25:23.397Z" },
-    { url = "https://files.pythonhosted.org/packages/93/af/d63f25bcccd3d6f06fd518ba4a321f34a4370c67b579ca5c70b4a37721b4/msgpack-1.1.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:7e7b853bbc44fb03fbdba34feb4bd414322180135e2cb5164f20ce1c9795ee48", size = 84277, upload-time = "2024-09-10T04:24:34.656Z" },
-    { url = "https://files.pythonhosted.org/packages/92/9b/5c0dfb0009b9f96328664fecb9f8e4e9c8a1ae919e6d53986c1b813cb493/msgpack-1.1.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:f3e9b4936df53b970513eac1758f3882c88658a220b58dcc1e39606dccaaf01c", size = 81357, upload-time = "2024-09-10T04:24:56.603Z" },
-    { url = "https://files.pythonhosted.org/packages/d1/7c/3a9ee6ec9fc3e47681ad39b4d344ee04ff20a776b594fba92d88d8b68356/msgpack-1.1.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:46c34e99110762a76e3911fc923222472c9d681f1094096ac4102c18319e6468", size = 371256, upload-time = "2024-09-10T04:25:11.473Z" },
-    { url = "https://files.pythonhosted.org/packages/f7/0a/8a213cecea7b731c540f25212ba5f9a818f358237ac51a44d448bd753690/msgpack-1.1.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8a706d1e74dd3dea05cb54580d9bd8b2880e9264856ce5068027eed09680aa74", size = 377868, upload-time = "2024-09-10T04:25:24.535Z" },
-    { url = "https://files.pythonhosted.org/packages/1b/94/a82b0db0981e9586ed5af77d6cfb343da05d7437dceaae3b35d346498110/msgpack-1.1.0-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:534480ee5690ab3cbed89d4c8971a5c631b69a8c0883ecfea96c19118510c846", size = 363370, upload-time = "2024-09-10T04:24:21.812Z" },
-    { url = "https://files.pythonhosted.org/packages/93/fc/6c7f0dcc1c913e14861e16eaf494c07fc1dde454ec726ff8cebcf348ae53/msgpack-1.1.0-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:8cf9e8c3a2153934a23ac160cc4cba0ec035f6867c8013cc6077a79823370346", size = 358970, upload-time = "2024-09-10T04:24:24.741Z" },
-    { url = "https://files.pythonhosted.org/packages/1f/c6/e4a04c0089deace870dabcdef5c9f12798f958e2e81d5012501edaff342f/msgpack-1.1.0-cp39-cp39-musllinux_1_2_i686.whl", hash = "sha256:3180065ec2abbe13a4ad37688b61b99d7f9e012a535b930e0e683ad6bc30155b", size = 366358, upload-time = "2024-09-10T04:25:45.955Z" },
-    { url = "https://files.pythonhosted.org/packages/b6/54/7d8317dac590cf16b3e08e3fb74d2081e5af44eb396f0effa13f17777f30/msgpack-1.1.0-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:c5a91481a3cc573ac8c0d9aace09345d989dc4a0202b7fcb312c88c26d4e71a8", size = 370336, upload-time = "2024-09-10T04:24:26.918Z" },
-    { url = "https://files.pythonhosted.org/packages/dc/6f/a5a1f43b6566831e9630e5bc5d86034a8884386297302be128402555dde1/msgpack-1.1.0-cp39-cp39-win32.whl", hash = "sha256:f80bc7d47f76089633763f952e67f8214cb7b3ee6bfa489b3cb6a84cfac114cd", size = 68683, upload-time = "2024-09-10T04:24:32.984Z" },
-    { url = "https://files.pythonhosted.org/packages/5f/e8/2162621e18dbc36e2bc8492fd0e97b3975f5d89fe0472ae6d5f7fbdd8cf7/msgpack-1.1.0-cp39-cp39-win_amd64.whl", hash = "sha256:4d1b7ff2d6146e16e8bd665ac726a89c74163ef8cd39fa8c1087d4e52d3a2325", size = 74787, upload-time = "2024-09-10T04:25:14.524Z" },
 ]
 
 [[package]]
@@ -372,11 +335,11 @@ wheels = [
 
 [[package]]
 name = "platformdirs"
-version = "4.3.8"
+version = "4.5.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/fe/8b/3c73abc9c759ecd3f1f7ceff6685840859e8070c4d947c93fae71f6a0bf2/platformdirs-4.3.8.tar.gz", hash = "sha256:3d512d96e16bcb959a814c9f348431070822a6496326a4be0911c40b5a74c2bc", size = 21362, upload-time = "2025-05-07T22:47:42.121Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/cf/86/0248f086a84f01b37aaec0fa567b397df1a119f73c16f6c7a9aac73ea309/platformdirs-4.5.1.tar.gz", hash = "sha256:61d5cdcc6065745cdd94f0f878977f8de9437be93de97c1c12f853c9c0cdcbda", size = 21715, upload-time = "2025-12-05T13:52:58.638Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/fe/39/979e8e21520d4e47a0bbe349e2713c0aac6f3d853d0e5b34d76206c439aa/platformdirs-4.3.8-py3-none-any.whl", hash = "sha256:ff7059bb7eb1179e2685604f4aaf157cfd9535242bd23742eadc3c13542139b4", size = 18567, upload-time = "2025-05-07T22:47:40.376Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/28/3bfe2fa5a7b9c46fe7e13c97bda14c895fb10fa2ebf1d0abb90e0cea7ee1/platformdirs-4.5.1-py3-none-any.whl", hash = "sha256:d03afa3963c806a9bed9d5125c8f4cb2fdaf74a55ab60e5d59b3fde758104d31", size = 18731, upload-time = "2025-12-05T13:52:56.823Z" },
 ]
 
 [[package]]
@@ -412,11 +375,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/d4/5e/63f5cbde2342b7f70a39e591dbe75d9809d6338ce0b07c10406f1a140cdc/pycryptodome-3.23.0-pp310-pypy310_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:14e15c081e912c4b0d75632acd8382dfce45b258667aa3c67caf7a4d4c13f630", size = 1664461, upload-time = "2025-05-17T17:21:25.225Z" },
     { url = "https://files.pythonhosted.org/packages/d6/92/608fbdad566ebe499297a86aae5f2a5263818ceeecd16733006f1600403c/pycryptodome-3.23.0-pp310-pypy310_pp73-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:a7fc76bf273353dc7e5207d172b83f569540fc9a28d63171061c42e361d22353", size = 1702440, upload-time = "2025-05-17T17:21:27.991Z" },
     { url = "https://files.pythonhosted.org/packages/d1/92/2eadd1341abd2989cce2e2740b4423608ee2014acb8110438244ee97d7ff/pycryptodome-3.23.0-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:45c69ad715ca1a94f778215a11e66b7ff989d792a4d63b68dc586a1da1392ff5", size = 1803005, upload-time = "2025-05-17T17:21:31.37Z" },
-    { url = "https://files.pythonhosted.org/packages/dc/c4/6925ad41576d3e84f03aaf9a0411667af861f9fa2c87553c7dd5bde01518/pycryptodome-3.23.0-pp39-pypy39_pp73-macosx_10_15_x86_64.whl", hash = "sha256:865d83c906b0fc6a59b510deceee656b6bc1c4fa0d82176e2b77e97a420a996a", size = 1623768, upload-time = "2025-05-17T17:21:33.418Z" },
-    { url = "https://files.pythonhosted.org/packages/a8/14/d6c6a3098ddf2624068f041c5639be5092ad4ae1a411842369fd56765994/pycryptodome-3.23.0-pp39-pypy39_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:89d4d56153efc4d81defe8b65fd0821ef8b2d5ddf8ed19df31ba2f00872b8002", size = 1672070, upload-time = "2025-05-17T17:21:35.565Z" },
-    { url = "https://files.pythonhosted.org/packages/20/89/5d29c8f178fea7c92fd20d22f9ddd532a5e3ac71c574d555d2362aaa832a/pycryptodome-3.23.0-pp39-pypy39_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e3f2d0aaf8080bda0587d58fc9fe4766e012441e2eed4269a77de6aea981c8be", size = 1664359, upload-time = "2025-05-17T17:21:37.551Z" },
-    { url = "https://files.pythonhosted.org/packages/38/bc/a287d41b4421ad50eafb02313137d0276d6aeffab90a91e2b08f64140852/pycryptodome-3.23.0-pp39-pypy39_pp73-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:64093fc334c1eccfd3933c134c4457c34eaca235eeae49d69449dc4728079339", size = 1702359, upload-time = "2025-05-17T17:21:39.827Z" },
-    { url = "https://files.pythonhosted.org/packages/2b/62/2392b7879f4d2c1bfa20815720b89d464687877851716936b9609959c201/pycryptodome-3.23.0-pp39-pypy39_pp73-win_amd64.whl", hash = "sha256:ce64e84a962b63a47a592690bdc16a7eaf709d2c2697ababf24a0def566899a6", size = 1802461, upload-time = "2025-05-17T17:21:41.722Z" },
 ]
 
 [[package]]
@@ -434,7 +392,6 @@ version = "6.10.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "altgraph" },
-    { name = "importlib-metadata", marker = "python_full_version < '3.10'" },
     { name = "macholib", marker = "sys_platform == 'darwin'" },
     { name = "packaging" },
     { name = "pefile", marker = "sys_platform == 'win32'" },
@@ -462,7 +419,6 @@ name = "pyinstaller-hooks-contrib"
 version = "2025.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "importlib-metadata", marker = "python_full_version < '3.10'" },
     { name = "packaging" },
     { name = "setuptools" },
 ]
@@ -509,8 +465,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/6c/c3/51aca6887cc5e410aa4cdc55662cf8438212440c67335c3f141b02eb8d52/pywin32-309-cp313-cp313-win32.whl", hash = "sha256:008bffd4afd6de8ca46c6486085414cc898263a21a63c7f860d54c9d02b45c8d", size = 8789700, upload-time = "2025-03-09T18:04:08.937Z" },
     { url = "https://files.pythonhosted.org/packages/dd/66/330f265140fa814b4ed1bf16aea701f9d005f8f4ab57a54feb17f53afe7e/pywin32-309-cp313-cp313-win_amd64.whl", hash = "sha256:bd0724f58492db4cbfbeb1fcd606495205aa119370c0ddc4f70e5771a3ab768d", size = 9496714, upload-time = "2025-03-09T18:04:10.619Z" },
     { url = "https://files.pythonhosted.org/packages/2c/84/9a51e6949a03f25cd329ece54dbf0846d57fadd2e79046c3b8d140aaa132/pywin32-309-cp313-cp313-win_arm64.whl", hash = "sha256:8fd9669cfd41863b688a1bc9b1d4d2d76fd4ba2128be50a70b0ea66b8d37953b", size = 8453052, upload-time = "2025-03-09T18:04:12.812Z" },
-    { url = "https://files.pythonhosted.org/packages/80/a2/9c0c9bda69e5064b616d4484624e097c13b2a2dfffe601609a1cb8e68ba1/pywin32-309-cp39-cp39-win32.whl", hash = "sha256:72ae9ae3a7a6473223589a1621f9001fe802d59ed227fd6a8503c9af67c1d5f4", size = 8842771, upload-time = "2025-03-09T18:03:46.448Z" },
-    { url = "https://files.pythonhosted.org/packages/89/a5/390fbc106b5998296515d5a88730c6de472a6ed5f051db66d4cc46dd50fd/pywin32-309-cp39-cp39-win_amd64.whl", hash = "sha256:88bc06d6a9feac70783de64089324568ecbc65866e2ab318eab35da3811fd7ef", size = 9594766, upload-time = "2025-03-09T18:03:48.797Z" },
 ]
 
 [[package]]
@@ -619,7 +573,7 @@ dependencies = [
 
 [package.dev-dependencies]
 build = [
-    { name = "pyinstaller", marker = "python_full_version != '3.10.*'" },
+    { name = "pyinstaller", marker = "python_full_version >= '3.11'" },
     { name = "pypiwin32", marker = "sys_platform == 'win32'" },
 ]
 dev = [
@@ -629,16 +583,16 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "backoff", specifier = "==2.2.1" },
-    { name = "cachecontrol", specifier = "==0.14.2" },
-    { name = "dataclass-wizard", specifier = "==0.35.1" },
+    { name = "cachecontrol", specifier = "==0.14.3" },
+    { name = "dataclass-wizard", specifier = "==0.39.1" },
     { name = "ffmpeg-python", specifier = "==0.2.0" },
     { name = "m3u8", specifier = "==6.0.0" },
     { name = "mutagen", specifier = "==1.47.0" },
-    { name = "platformdirs", specifier = "==4.3.8" },
+    { name = "platformdirs", specifier = "==4.5.1" },
     { name = "pycryptodome", specifier = "==3.23.0" },
     { name = "requests", extras = ["socks"], specifier = ">=2.32.4" },
-    { name = "typer", specifier = "==0.20.0" },
-    { name = "tzdata", marker = "sys_platform == 'win32'", specifier = "==2025.2" },
+    { name = "typer", specifier = "==0.23.1" },
+    { name = "tzdata", marker = "sys_platform == 'win32'", specifier = "==2025.3" },
 ]
 
 [package.metadata.requires-dev]
@@ -650,35 +604,35 @@ dev = [{ name = "ruff" }]
 
 [[package]]
 name = "typer"
-version = "0.20.0"
+version = "0.23.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
+    { name = "annotated-doc" },
     { name = "click" },
     { name = "rich" },
     { name = "shellingham" },
-    { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/8f/28/7c85c8032b91dbe79725b6f17d2fffc595dff06a35c7a30a37bef73a1ab4/typer-0.20.0.tar.gz", hash = "sha256:1aaf6494031793e4876fb0bacfa6a912b551cf43c1e63c800df8b1a866720c37", size = 106492, upload-time = "2025-10-20T17:03:49.445Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/fd/07/b822e1b307d40e263e8253d2384cf98c51aa2368cc7ba9a07e523a1d964b/typer-0.23.1.tar.gz", hash = "sha256:2070374e4d31c83e7b61362fd859aa683576432fd5b026b060ad6b4cd3b86134", size = 120047, upload-time = "2026-02-13T10:04:30.984Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/78/64/7713ffe4b5983314e9d436a90d5bd4f63b6054e2aca783a3cfc44cb95bbf/typer-0.20.0-py3-none-any.whl", hash = "sha256:5b463df6793ec1dca6213a3cf4c0f03bc6e322ac5e16e13ddd622a889489784a", size = 47028, upload-time = "2025-10-20T17:03:47.617Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/91/9b286ab899c008c2cb05e8be99814807e7fbbd33f0c0c960470826e5ac82/typer-0.23.1-py3-none-any.whl", hash = "sha256:3291ad0d3c701cbf522012faccfbb29352ff16ad262db2139e6b01f15781f14e", size = 56813, upload-time = "2026-02-13T10:04:32.008Z" },
 ]
 
 [[package]]
 name = "typing-extensions"
-version = "4.12.2"
+version = "4.15.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/df/db/f35a00659bc03fec321ba8bce9420de607a1d37f8342eee1863174c69557/typing_extensions-4.12.2.tar.gz", hash = "sha256:1a7ead55c7e559dd4dee8856e3a88b41225abfe1ce8df57b7c13915fe121ffb8", size = 85321, upload-time = "2024-06-07T18:52:15.995Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466", size = 109391, upload-time = "2025-08-25T13:49:26.313Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/26/9f/ad63fc0248c5379346306f8668cda6e2e2e9c95e01216d2b8ffd9ff037d0/typing_extensions-4.12.2-py3-none-any.whl", hash = "sha256:04e5ca0351e0f3f85c6853954072df659d0d13fac324d0072316b67d7794700d", size = 37438, upload-time = "2024-06-07T18:52:13.582Z" },
+    { url = "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548", size = 44614, upload-time = "2025-08-25T13:49:24.86Z" },
 ]
 
 [[package]]
 name = "tzdata"
-version = "2025.2"
+version = "2025.3"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/95/32/1a225d6164441be760d75c2c42e2780dc0873fe382da3e98a2e1e48361e5/tzdata-2025.2.tar.gz", hash = "sha256:b60a638fcc0daffadf82fe0f57e53d06bdec2f36c4df66280ae79bce6bd6f2b9", size = 196380, upload-time = "2025-03-23T13:54:43.652Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/5e/a7/c202b344c5ca7daf398f3b8a477eeb205cf3b6f32e7ec3a6bac0629ca975/tzdata-2025.3.tar.gz", hash = "sha256:de39c2ca5dc7b0344f2eba86f49d614019d29f060fc4ebc8a417896a620b56a7", size = 196772, upload-time = "2025-12-13T17:45:35.667Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5c/23/c7abc0ca0a1526a0774eca151daeb8de62ec457e77262b66b359c3c7679e/tzdata-2025.2-py2.py3-none-any.whl", hash = "sha256:1a403fada01ff9221ca8044d701868fa132215d84beb92242d9acd2147f667a8", size = 347839, upload-time = "2025-03-23T13:54:41.845Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/b0/003792df09decd6849a5e39c28b513c06e84436a54440380862b5aeff25d/tzdata-2025.3-py2.py3-none-any.whl", hash = "sha256:06a47e5700f3081aab02b2e513160914ff0694bce9947d6b76ebd6bf57cfc5d1", size = 348521, upload-time = "2025-12-13T17:45:33.889Z" },
 ]
 
 [[package]]
@@ -688,13 +642,4 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/aa/63/e53da845320b757bf29ef6a9062f5c669fe997973f966045cb019c3f4b66/urllib3-2.3.0.tar.gz", hash = "sha256:f8c5449b3cf0861679ce7e0503c7b44b5ec981bec0d1d3795a07f1ba96f0204d", size = 307268, upload-time = "2024-12-22T07:47:30.032Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c8/19/4ec628951a74043532ca2cf5d97b7b14863931476d117c471e8e2b1eb39f/urllib3-2.3.0-py3-none-any.whl", hash = "sha256:1cee9ad369867bfdbbb48b7dd50374c0967a0bb7710050facf0dd6911440e3df", size = 128369, upload-time = "2024-12-22T07:47:28.074Z" },
-]
-
-[[package]]
-name = "zipp"
-version = "3.21.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/3f/50/bad581df71744867e9468ebd0bcd6505de3b275e06f202c2cb016e3ff56f/zipp-3.21.0.tar.gz", hash = "sha256:2c9958f6430a2040341a52eb608ed6dd93ef4392e02ffe219417c1b28b5dd1f4", size = 24545, upload-time = "2024-11-10T15:05:20.202Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/b7/1a/7e4798e9339adc931158c9d69ecc34f5e6791489d469f5e50ec15e35f458/zipp-3.21.0-py3-none-any.whl", hash = "sha256:ac1bbe05fd2991f160ebce24ffbac5f6d11d83dc90891255885223d42b3cd931", size = 9630, upload-time = "2024-11-10T15:05:19.275Z" },
 ]


### PR DESCRIPTION
The dependabot pull requests open on the `development` branch have been failing because `pyproject.toml` does not specify the `requires-python` syntax correctly.

This pull request does a number of things to address that:
  - Update the versions of the various `actions/<action>` used in the Workflows
  - Fix some typing now that Python 3.10 is the minimum-supported version for `tidal-wave`
  - Use `uv` in all Actions for speed and simplicity
  - Fix `python-lint.yml` to point to the new `src/` directory structure
  - Bump Python dependence versions