### PR TITLE
Use Python 3.13 for PyInstaller Workflow

### DIFF
--- a/.github/workflows/pyinstaller-windows.yml
+++ b/.github/workflows/pyinstaller-windows.yml
@@ -53,13 +53,13 @@ jobs:
         with:
           architecture: "x64"
           check-latest: false
-          python-version: "3.14.3"
+          python-version: "3.13.12"
 
       - name: Install uv
         uses: astral-sh/setup-uv@eac588ad8def6316056a12d4907a9d4d84ff7a3b  # v7.3.0
         with:
           enable-cache: true
-          python-version: '3.14.3'
+          python-version: "3.13.12"
 
       - name: Install dependencies
         env:

--- a/BUILDME.md
+++ b/BUILDME.md
@@ -1,11 +1,11 @@
 # Python Package
 
 `tidal-wave` is, first and foremost, a Python project that is built and uploaded to PyPi. Indeed, that is the sole purpose of `pyproject.toml` and `setup.py` at the root of the repository. No frameworks are used for this process such as `poetry` or `pipenv`, just the standard Python `setuptools` and `build`. To that end, the process of building a Python package for a given release is
-  1. change the line `__version__ = ` in [`tidal_wave/main.py`](https://github.com/ebb-earl-co/tidal-wave/blob/trunk/tidal_wave/main.py#L32) to a new version. At the time of writing this, that would be `"2024.8.1"`. This is because PyPi disallows package name/version duplicates.
+  1. change the line `__version__ = ` in [`tidal_wave/main.py`](https://github.com/ebb-earl-co/tidal-wave/blob/trunk/tidal_wave/main.py#L32) to a new version. At the time of writing this, that would be `"2025.11.1"`. This is because PyPi disallows package name/version duplicates.
   2. With a Python virtual environment, or, e.g. on a Debian-based OS, install the APT package `python3-build`; or, with the OS's system-wide Python3 installation, install the `build` package.
     - I like to have a Python3 virtual environment created with the system Python3 in my home directory for all the bits and bobs required in development: `~/.venv`
   3. From the repository root, simply run `$ python3 -m build` (or, on Windows, `PS> .venv\Scripts\python.exe -m build`) and let the process run its course.
-  4. Once that process has finished, there will be two new files in the `dist` subdirectory of the repository root: `dist/tidal-wave-2024.8.1.tar.gz`, and `tidal_wave-2024.8.1-py3-none-any.whl`.
+  4. Once that process has finished, there will be two new files in the `dist` subdirectory of the repository root: `dist/tidal-wave-2025.11.1.tar.gz`, and `tidal_wave-2025.11.1-py3-none-any.whl`.
   5. These binaries are uploaded to PyPi using GitHub Actions: in particular, the [`.github/workflows/python-build.yml`](https://github.com/ebb-earl-co/tidal-wave/blob/trunk/.github/workflows/python-build.yml) file
 
 # `pyinstaller`-Created Binaries
@@ -15,7 +15,7 @@ However, PyInstaller wants to package up a single Python script into an easily-d
   1. Create virtual environment in repository root: `$ "$(command -v python3)" -m venv ./venv` and install `tidal-wave`'s dependencies
    - `$ ./venv/bin/python3 -m pip install --upgrade pip setuptools wheel`
    - `$ ./venv/bin/python3 -m pip install .`
-   - `$ ./venv/bin/python3 -m pip install pyinstaller==6.17.0`
+   - `$ ./venv/bin/python3 -m pip install pyinstaller==6.19.0`
   2. Without compiling FFmpeg from source, the command is very simple:
   ```bash
   ./venv/bin/pyinstaller \
@@ -67,6 +67,7 @@ Now, FFmpeg has a dizzying array of configuration options because it supports a 
 
 Only a few dependencies are necessary, but most important of them is a C/C++ compiler, such as `gcc`. On a Debian-based system, the following APT packages are the only requirements:
  - `ca-certificates`
+ - `ccache`  (optional; can speed up compilation)
  - `g++`
  - `gcc`
  - `git`

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ More information on sound quality at [TIDAL's site here](https://tidal.com/sound
    - For macOS, the [FFmpeg download page](http://ffmpeg.org/download.html#build-mac) links to [this download source](https://evermeet.cx/ffmpeg/); or there is always [Homebrew](https://formulae.brew.sh/formula/ffmpeg)
    - For Windows, the [FFmpeg download page](http://ffmpeg.org/download.html#build-windows) lists 2 resources; or [`chocolatey`](https://community.chocolatey.org/packages/ffmpeg) is an option
    - If a minimal FFmpeg, compiled from source, is desired, take a look at this project's [BUILDME.md](https://github.com/ebb-earl-co/tidal-wave/blob/trunk/BUILDME.md) file for decent instructions
- - This is a Python package, so **to use it in the default manner** you will need [Python 3](https://www.python.org/downloads/), version 3.8 or newer, on your system.
+ - This is a Python package, so **to use it in the default manner** you will need [Python 3](https://www.python.org/downloads/), version 3.10 or newer, on your system.
    - *However*, as of December 2023, an [OCI container image](https://github.com/ebb-earl-co/tidal-wave/pkgs/container/tidal-wave); and [PyInstaller](https://pyinstaller.org/en/stable/)-created binaries for x86\_64 GNU/Linux, Apple Silicon macOS, x86\_64 macOS, and x86\_64 Windows are provided for download and use that *do not require Python to be installed*
  - Only a handful of Python libraries are dependencies:
    - [`backoff`](https://pypi.org/project/backoff/)
@@ -98,13 +98,12 @@ PS> uvx.exe tidal-wave --help
 It _really_ is that simple and straightforward! Repeated uses of `tidal-wave` via this declaration will be much faster, as the project and its dependencies will have been stored in `uv`'s cache.
 
 ### PyInstaller executable
-The release artifacts for this project are created with [PyInstaller](https://pyinstaller.org). It bundles Python 3.12.9, FFmpeg 7.0, and the `tidal-wave` program into one binary, licensed under the terms of FFmpeg: with the [GNU Lesser General Public License (LGPL) version 2.1](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.html). Installation is as simple as downloading the correct binary for your platform giving it execute permissions, and running it. **Please make sure that the SHA256 checksum of the file that you have downloaded matches the corresponding `.sha256` file on the releases page!**
+The release artifacts for this project are created with [PyInstaller](https://pyinstaller.org). It bundles Python 3.14.3 (Python 3.13.12 for the Windows version due to `pywin32`) FFmpeg 7.0, and the `tidal-wave` program into one binary, licensed under the terms of FFmpeg: with the [GNU Lesser General Public License (LGPL) version 2.1](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.html). Installation is as simple as downloading the correct binary for your platform giving it execute permissions, and running it. **Please make sure that the SHA256 checksum of the file that you have downloaded matches the corresponding SHA-256 annotation on the releases page!**
 #### On Unix-Like
 ```bash
 $ wget https://github.com/ebb-earl-co/tidal-wave/releases/latest/download/tidal-wave_ubuntu_24.04_amd64
-$ wget https://github.com/ebb-earl-co/tidal-wave/releases/latest/download/tidal-wave_ubuntu_24.04_amd64.sha256
-$ sha256sum --check tidal-wave_ubuntu_24.04_amd64.sha256
-# ONLY CONTINUE IF THE OUTPUT IS THE FOLLOWING: 'tidal-wave_ubuntu_24.04_amd64.sha256: OK'
+$ sha256sum tidal-wave_ubuntu_24.04_amd64
+# ONLY CONTINUE IF THE OUTPUT MATCHES THE GITHUB `sha256:` TEXT NEXT TO THE ASSET!
 # Otherwise, delete the downloaded binary and try to download it again
 $ chmod +x ./tidal-wave_ubuntu_24.04_amd64
 $ ./tidal-wave_ubuntu_24.04_amd64 --help
@@ -114,9 +113,7 @@ $ ./tidal-wave_ubuntu_24.04_amd64 --help
 # For just the lifetime of this PowerShell process, don't block the download from GitHub
 PS > Set-ExecutionPolicy -ExecutionPolicy Bypass -Scope Process
 PS > Invoke-WebRequest "https://github.com/ebb-earl-co/tidal-wave/releases/latest/download/tidal-wave_windows.exe" -OutFile "tidal-wave_windows.exe"
-PS > Invoke-WebRequest "https://github.com/ebb-earl-co/tidal-wave/releases/latest/download/tidal-wave_windows.exe.sha256" -OutFile "tidal-wave_windows.exe.sha256"
-# Get the checksum value from the tidal-wave_windows.exe.sha256 file and compare it to the just-downloaded EXE
-# (Get-FileHash .\tidal-wave_windows.exe -Algorithm SHA256).Hash -eq (Get-Content .\tidal-wave_windows.exe.sha256).split("`t")[0]
+# Get the checksum value from GitHub and compare it to the just-downloaded EXE
 PS > (Get-FileHash .\tidal-wave_windows.exe -Algorithm SHA256).Hash -eq "e02f69eb850a98e6e1df2bc033fd12566cf27305421a36ec5372fd432ccc8e70"  # This checksum is from version 2024.4.3
 # ONLY CONTINUE IF THE OUTPUT OF THE PREVIOUS COMMAND IS 'True'
 PS > & .\tidal-wave_windows.exe --help
@@ -309,14 +306,14 @@ $ docker exec -it tidal-wave tidal-wave https://tidal.com/browse/track/...
 Note: the first `tidal-wave` is whatever `--name` you give the container, so that can be whatever your heart desires, but the second `tidal-wave` is invoking the Python program *inside* the container and needs to exactly `tidal-wave`.
 ## Development
 The easiest way to start working on development is to fork this project on GitHub, or clone the repository to your local machine and do the pull requesting on GitHub later. In any case, there will need to be some getting from GitHub first, so, roughly, the process is:
-  1. Get Python 3.8+ on your system
-  2. Use a virtualenv or some other Python environment system (poetry, pipenv, etc.)
-  3. Clone the repository: `$ git clone --depth=1 https://github.com/ebb-earl-co/tidal-wave/git`
+  1. Get Python 3.10+ on your system (or, install `uv` and it can fetch Python interpreters on the fly with `uv python install`)
+  2. Use a virtualenv or some other Python environment system (poetry, pipenv, etc.) **Really, just use `uv`.***
+  3. Clone the repository: `$ git clone --depth=1 https://github.com/ebb-earl-co/tidal-wave.git`
 
     * Obviously replace the URL with your forked version if you've followed that strategy
-  4. Activate the virtual environment and install the required packages (requirements.txt): `(some-virtual-env) $ python3 -m pip install -r requirements.txt`
+  4. Activate the virtual environment and install the required packages (requirements.txt): `(some-virtual-env) $ python3 -m pip install .`
 
-    * optional packages to follow the coding style and build process; `pyinstaller`, `black`: `(some-virtual-env) $ python3 -m pip install black pyinstaller`
+    * optional packages to follow the coding style and build process; `pyinstaller`, `ruff`: `(some-virtual-env) $ python3 -m pip install --group build --group dev`
     * optionally, Docker to build the OCI container artifacts
   5. From a Python REPL (or, my preferred method, an iPython session), import all the relevant modules, or the targeted ones for development:
   ```python


### PR DESCRIPTION
The PyInstaller project requires `pywin32` when used on Windows systems, and that dependence does not have ABI-compatible wheels for Python 3.14.

This pull request changes it so that the PyInstaller Windows binary includes Python 3.13.12 instead of Python 3.14.3 that all the other flavors bundle in (for now, until another similar issue arises...).

Also, this pull request updates the two Markdown files, `README.md` and `BUILDME.md`, to have more up-to-date information about processes and the state of the project.